### PR TITLE
Fix GPU Acceleration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,8 +103,13 @@ jobs:
             ## 🎉 stem-splitter-core v${{ steps.version.outputs.VERSION }}
 
             ### Changes
-            - Improve execution provider fallback (sequential EP attempts with CPU fallback)
-            - Add `STEMMER_FORCE_CPU` escape hatch for debugging
+            - Improve acceleration reliability with better execution-provider selection, health checks, and CPU fallback
+            - Add `XNNPACK` as an additional accelerated fallback alongside CUDA, CoreML, DirectML, and oneDNN
+            - Reduce end-to-end split time with streaming stem writes, reused hot-path buffers, and lower post-processing overhead
+            - Add advanced tuning controls for provider selection, CoreML, ONNX Runtime threading, and performance diagnostics
+
+            ### Performance
+            - Up to ~40% faster end-to-end split times in internal testing, depending on hardware and provider
 
             ### Installation
             ```toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-04-13
+
+### ⚡ Performance & Acceleration
+
+This release focuses on making real-world splitting faster and making automatic
+acceleration more reliable across platforms.
+
+### Added
+- `XNNPACK` execution provider support as an additional accelerated fallback
+- Early execution-provider health probing during preload to reject bad providers before split work starts
+- Advanced acceleration tuning controls for CoreML and ONNX Runtime threading
+- Per-window performance diagnostics via `STEMMER_PERF=1`
+- Successful provider probe caching to reduce repeated startup overhead on known-good configurations
+
+### Changed
+- Improved automatic execution-provider ordering by OS and architecture
+- Apple Silicon now uses a more reliable `CoreML -> XNNPACK -> CPU` fallback path
+- CoreML sessions now use more explicit model/tuning options and compiled model caching
+- Stem writing now streams directly to output WAV files instead of building full-track accumulators in memory
+- Engine inference now reuses hot-path buffers, caches input binding strategy, and minimizes session lock scope
+- iSTFT reconstruction now reuses workspace buffers and accumulates directly into final output buffers
+
+### Performance
+- Up to ~40% faster end-to-end split times in internal testing, depending on hardware and provider
+- Large real-world improvement observed versus older builds in downstream app integration testing
+- Lower memory overhead during long splits due to streaming writes and reduced post-processing copies
+
+### Fixed
+- CoreML silent/near-silent output is now detected earlier and falls back more safely
+- Model manager tests now use isolated cache/model names so the full test suite is stable across repeated runs
+
 ## [1.1.0] - 2024-11-29
 
 ### ⚡ Performance & GPU Acceleration
@@ -58,7 +89,7 @@ This is a **major architectural change** moving from Python-based processing to 
 
 Earlier versions (< 1.0.0) used a Python-based approach and are not compatible with this release.
 
-[Unreleased]: https://github.com/gentij/stem-splitter-core/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/gentij/stem-splitter-core/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/gentij/stem-splitter-core/releases/tag/v1.2.0
 [1.1.0]: https://github.com/gentij/stem-splitter-core/releases/tag/v1.1.0
 [1.0.0]: https://github.com/gentij/stem-splitter-core/releases/tag/v1.0.0
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,15 +493,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,18 +686,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "filetime"
-version = "0.2.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,16 +696,6 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "flate2"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fnv"
@@ -928,6 +891,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
 name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,7 +1038,7 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "pin-utils",
- "smallvec 1.15.1",
+ "smallvec",
  "tokio",
  "want",
 ]
@@ -1169,7 +1138,7 @@ dependencies = [
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec 1.15.1",
+ "smallvec",
  "zerovec",
 ]
 
@@ -1225,7 +1194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
- "smallvec 1.15.1",
+ "smallvec",
  "utf8_iter",
 ]
 
@@ -1362,7 +1331,6 @@ checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
- "redox_syscall",
 ]
 
 [[package]]
@@ -1396,6 +1364,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-rust2"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,16 +1390,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
 
 [[package]]
 name = "mio"
@@ -1470,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
  "matrixmultiply",
  "num-complex",
@@ -1580,26 +1544,25 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e49bd669d32d7bc2a15ec540a527e7764aec722a45467814005725bcd721"
+checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
 dependencies = [
- "ndarray 0.16.1",
+ "ndarray 0.17.2",
  "ort-sys",
- "smallvec 2.0.0-alpha.10",
+ "smallvec",
  "tracing",
+ "ureq",
 ]
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2aba9f5c7c479925205799216e7e5d07cc1d4fa76ea8058c60a9a30f6a4e890"
+checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
 dependencies = [
- "flate2",
- "pkg-config",
- "sha2",
- "tar",
+ "hmac-sha256",
+ "lzma-rust2",
  "ureq",
 ]
 
@@ -1628,7 +1591,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.15.1",
+ "smallvec",
  "windows-link 0.2.1",
 ]
 
@@ -2189,12 +2152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,12 +2174,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "smallvec"
-version = "2.0.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b"
 
 [[package]]
 name = "socket2"
@@ -2526,17 +2477,6 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "tar"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
 ]
 
 [[package]]
@@ -3286,16 +3226,6 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
-
-[[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix",
-]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,7 +2214,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stem-splitter-core"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ httpmock = "0.7"              # to simulate remote manifest/model servers
 tempfile = "3.8"              # also used in tests for isolated dirs
 
 [features]
-default = ["cuda", "coreml", "directml", "onednn"]
+default = ["cuda", "coreml", "directml", "onednn", "xnnpack"]
 engine-mock = []
 
 # GPU acceleration providers - enable all by default, code handles platform detection
@@ -58,6 +58,7 @@ cuda = ["ort/cuda"]           # NVIDIA GPUs (Linux, Windows)
 coreml = ["ort/coreml"]       # Apple Silicon (macOS only)  
 directml = ["ort/directml"]   # DirectML (Windows only)
 onednn = ["ort/onednn"]       # Intel optimized (all platforms)
+xnnpack = ["ort/xnnpack"]     # ARM/x86 optimized CPU fallback
 
 [[bin]]
 name = "stem-splitter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ndarray = "0.15"
 anyhow = "1"        
 symphonia = { version = "0.5", features = ["mp3", "wav"] }
 tempfile = "3.8"
-ort = { version = "2.0.0-rc.10", features = ["download-binaries"] }
+ort = { version = "=2.0.0-rc.11", features = ["download-binaries"] }
 serde = { version="1", features=["derive"] }
 serde_json = "1"
 reqwest = { version="0.12", features=["blocking","json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stem-splitter-core"
-version = "1.1.3"
+version = "1.2.0"
 edition = "2021"
 description = "Core library for AI-powered audio stem separation"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -491,6 +491,11 @@ To apply this permanently in your shell:
 - `export STEMMER_EP_DISABLE=coreml`
   (or `export STEMMER_FORCE_CPU=1`)
 
+Quick troubleshooting:
+- Silent stems or very low output with GPU: `STEMMER_EP_DISABLE=coreml` (macOS) or disable the failing provider.
+- GPU forced for debugging but still bad output: remove `STEMMER_EP_FORCE` and let auto mode fallback.
+- Need detailed provider logs: set `DEBUG_STEMS=1`.
+
 **Q: What's the quality compared to Python Demucs?**  
 A: Identical quality - we use the same model architecture, just optimized for ONNX.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Perfect for music production tools, DJ software, karaoke apps, or any applicatio
 
 - 🎵 **4-Stem Separation** — Isolate vocals, drums, bass, and other instruments
 - 🧠 **State-of-the-art AI** — Hybrid Transformer Demucs model (htdemucs)
-- 🚀 **GPU Acceleration** — CUDA, CoreML, DirectML, and oneDNN support (auto-detected)
+- 🚀 **GPU Acceleration** — CUDA, CoreML, DirectML, oneDNN, and XNNPACK support (auto-detected)
 - 📦 **Model Registry** — Built-in model registry with support for multiple models
 - 🎚️ **Multiple Formats** — Supports WAV, MP3, FLAC, OGG, and more via Symphonia
 - 📊 **Progress Tracking** — Real-time callbacks for download and split progress
@@ -450,6 +450,89 @@ cargo build --release
 
 ---
 
+## GPU Acceleration & Performance Tuning
+
+GPU acceleration is enabled by default. The library automatically selects the
+best execution provider available on the current machine, validates provider
+output during early inference, and falls back if a provider is unavailable or
+unhealthy.
+
+In internal testing, the current runtime improvements delivered up to roughly
+40% faster end-to-end split times, depending on hardware, OS, and provider.
+
+### Default Provider Order
+
+- macOS Apple Silicon: `CoreML -> XNNPACK -> CPU`
+- Linux x86_64: `CUDA -> oneDNN -> XNNPACK -> CPU`
+- Linux arm64: `CUDA -> XNNPACK -> CPU`
+- Windows: `CUDA -> DirectML -> oneDNN -> XNNPACK -> CPU`
+
+Notes:
+- `XNNPACK` is a fast CPU-side fallback, not a GPU backend
+- `Auto` is the recommended default for most users
+- Unhealthy providers are cached per machine/model for 7 days so future runs can skip known-bad paths and start faster
+
+### Common Controls
+
+- `STEMMER_FORCE_CPU=1` — force CPU-only mode
+- `STEMMER_EP_FORCE=cpu|cuda|coreml|directml|onednn|xnnpack` — force a specific provider; fails if unavailable or unhealthy
+- `STEMMER_EP_DISABLE=coreml,directml,...` — disable one or more providers from auto mode
+- `DEBUG_STEMS=1` — print provider selection, fallback, and health diagnostics
+- `STEMMER_EP_CACHE_BYPASS=1` — ignore remembered unhealthy providers for one run
+- `STEMMER_EP_CACHE_RESET=1` — clear remembered unhealthy providers before selecting
+- `STEMMER_PERF=1` — print per-window performance timing breakdowns
+
+### Advanced Tuning
+
+ONNX Runtime threading:
+- `STEMMER_ORT_INTRA_THREADS=<n>`
+- `STEMMER_ORT_INTER_THREADS=<n>`
+- `STEMMER_ORT_PARALLEL=0|1`
+
+CoreML tuning on macOS:
+- `STEMMER_COREML_UNITS=all|gpu|ane|cpu`
+- `STEMMER_COREML_MODEL_FORMAT=mlprogram|neuralnetwork`
+- `STEMMER_COREML_SPECIALIZATION=default|fastprediction`
+- `STEMMER_COREML_STATIC_INPUTS=0|1`
+
+These advanced options are mainly useful for benchmarking or exposing expert
+controls in a GUI. For most users, `Auto` is still the best choice.
+
+### Common Examples
+
+```bash
+# Recommended: let the library auto-select the best provider
+cargo run --release --bin stem-splitter -- split --input song.mp3 --output ./out
+
+# Force CUDA on Linux/Windows NVIDIA systems
+STEMMER_EP_FORCE=cuda cargo run --release --bin stem-splitter -- split --input song.mp3 --output ./out
+
+# Force CoreML on Apple Silicon
+STEMMER_EP_FORCE=coreml cargo run --release --bin stem-splitter -- split --input song.mp3 --output ./out
+
+# Force XNNPACK for comparison testing
+STEMMER_EP_FORCE=xnnpack cargo run --release --bin stem-splitter -- split --input song.mp3 --output ./out
+
+# Force CPU-only mode for maximum stability
+STEMMER_FORCE_CPU=1 cargo run --release --bin stem-splitter -- split --input song.mp3 --output ./out
+
+# Skip CoreML and let auto mode fall through to the next provider
+STEMMER_EP_DISABLE=coreml cargo run --release --bin stem-splitter -- split --input song.mp3 --output ./out
+
+# Show provider diagnostics and timing breakdowns
+DEBUG_STEMS=1 STEMMER_PERF=1 cargo run --release --bin stem-splitter -- split --input song.mp3 --output ./out
+```
+
+### Troubleshooting
+
+- Silent stems or very low output with GPU: disable the failing provider and retry in auto mode, for example `STEMMER_EP_DISABLE=coreml`
+- GPU forced for debugging but still bad output: remove `STEMMER_EP_FORCE` and let auto mode fall back
+- Need to retest a previously skipped provider: use `STEMMER_EP_CACHE_BYPASS=1`
+- Need to clear all remembered unhealthy providers: use `STEMMER_EP_CACHE_RESET=1`
+- Need to benchmark a provider on one machine: combine `STEMMER_EP_FORCE=...` with `STEMMER_PERF=1`
+
+---
+
 ## 🤔 FAQ
 
 **Q: Why is the first run slow?**  
@@ -459,27 +542,7 @@ A: The model (~200MB) is downloaded on first use. Subsequent runs are instant.
 A: Models are cached in your system's standard cache directory with SHA-256 verification for integrity.
 
 **Q: Can I use GPU acceleration?**  
-A: Yes! GPU acceleration is enabled by default and works across all platforms:
-- **NVIDIA GPUs**: CUDA (Linux, Windows)
-- **Apple Silicon**: CoreML (M1/M2/M3/M4 Macs)
-- **Windows (any GPU)**: DirectML (NVIDIA, AMD, Intel)
-- **Intel**: oneDNN optimizations
-- **ARM/x86 CPU fallback**: XNNPACK acceleration when GPU EPs are unavailable or unhealthy
-
-The library automatically detects available hardware, validates execution provider output during early inference, and falls back to CPU when a provider is unhealthy. Unhealthy providers are cached per machine/model for 7 days so future runs skip known-bad EPs and start faster.
-
-You can control provider selection with environment variables:
-- `STEMMER_FORCE_CPU=1` — force CPU only
-- `STEMMER_EP_FORCE=cpu|cuda|coreml|directml|onednn|xnnpack` — force a specific provider (fails if unhealthy/unavailable)
-- `STEMMER_EP_DISABLE=coreml,directml,...` — disable providers from auto mode
-- `DEBUG_STEMS=1` — print provider selection and fallback diagnostics
-- `STEMMER_EP_CACHE_BYPASS=1` — ignore unhealthy EP cache for one run
-- `STEMMER_EP_CACHE_RESET=1` — clear unhealthy EP cache before selecting providers
-
-Optional ONNX Runtime thread tuning (advanced):
-- `STEMMER_ORT_INTRA_THREADS=<n>`
-- `STEMMER_ORT_INTER_THREADS=<n>`
-- `STEMMER_ORT_PARALLEL=0|1`
+A: Yes. GPU acceleration is enabled by default. See `GPU Acceleration & Performance Tuning` for provider order, examples, and advanced controls.
 
 Optional CoreML tuning (advanced, macOS):
 - `STEMMER_COREML_UNITS=all|gpu|ane|cpu`
@@ -488,26 +551,7 @@ Optional CoreML tuning (advanced, macOS):
 - `STEMMER_COREML_STATIC_INPUTS=0|1`
 
 **Q: GPU acceleration does not work on my machine. Can I skip it?**  
-A: Yes. If a provider is known to fail on your setup, disable it so it is not tried at all.
-
-Examples:
-- Skip CoreML on Apple Silicon (avoids repeated CoreML attempts):
-  - `STEMMER_EP_DISABLE=coreml cargo run --release --bin stem-splitter -- split --input song.mp3 --output ./out`
-- Force XNNPACK on Apple Silicon for comparison testing:
-  - `STEMMER_EP_FORCE=xnnpack cargo run --release --bin stem-splitter -- split --input song.mp3 --output ./out`
-- Force CPU-only mode (maximum stability):
-  - `STEMMER_FORCE_CPU=1 cargo run --release --bin stem-splitter -- split --input song.mp3 --output ./out`
-
-To apply this permanently in your shell:
-- `export STEMMER_EP_DISABLE=coreml`
-  (or `export STEMMER_FORCE_CPU=1`)
-
-Quick troubleshooting:
-- Silent stems or very low output with GPU: `STEMMER_EP_DISABLE=coreml` on Apple Silicon so auto mode can fall through to XNNPACK.
-- GPU forced for debugging but still bad output: remove `STEMMER_EP_FORCE` and let auto mode fallback.
-- Need detailed provider logs: set `DEBUG_STEMS=1`.
-- Need to retest a previously skipped GPU EP: use `STEMMER_EP_CACHE_BYPASS=1`.
-- Need to clear all remembered unhealthy EPs: use `STEMMER_EP_CACHE_RESET=1`.
+A: Yes. Use `STEMMER_FORCE_CPU=1` to force CPU-only mode, or `STEMMER_EP_DISABLE=...` to skip only the provider that is failing.
 
 **Q: What's the quality compared to Python Demucs?**  
 A: Identical quality - we use the same model architecture, just optimized for ONNX.
@@ -525,7 +569,7 @@ A: Input audio is automatically resampled to 44.1kHz for processing.
 
 ## 🗺️ Roadmap
 
-- [x] GPU acceleration (CUDA, CoreML, DirectML, oneDNN)
+- [x] GPU acceleration (CUDA, CoreML, DirectML, oneDNN, XNNPACK)
 - [ ] Additional model support (6-stem models with guitar/piano)
 - [ ] Real-time processing mode
 - [ ] Streaming API support

--- a/README.md
+++ b/README.md
@@ -465,13 +465,15 @@ A: Yes! GPU acceleration is enabled by default and works across all platforms:
 - **Windows (any GPU)**: DirectML (NVIDIA, AMD, Intel)
 - **Intel**: oneDNN optimizations
 
-The library automatically detects available hardware, validates execution provider output during early inference, and falls back to CPU when a provider is unhealthy. This prevents "selected but silent" provider failures while keeping startup fast.
+The library automatically detects available hardware, validates execution provider output during early inference, and falls back to CPU when a provider is unhealthy. Unhealthy providers are cached per machine/model for 7 days so future runs skip known-bad EPs and start faster.
 
 You can control provider selection with environment variables:
 - `STEMMER_FORCE_CPU=1` — force CPU only
 - `STEMMER_EP_FORCE=cpu|cuda|coreml|directml|onednn` — force a specific provider (fails if unhealthy/unavailable)
 - `STEMMER_EP_DISABLE=coreml,directml,...` — disable providers from auto mode
 - `DEBUG_STEMS=1` — print provider selection and fallback diagnostics
+- `STEMMER_EP_CACHE_BYPASS=1` — ignore unhealthy EP cache for one run
+- `STEMMER_EP_CACHE_RESET=1` — clear unhealthy EP cache before selecting providers
 
 Optional ONNX Runtime thread tuning (advanced):
 - `STEMMER_ORT_INTRA_THREADS=<n>`
@@ -495,6 +497,8 @@ Quick troubleshooting:
 - Silent stems or very low output with GPU: `STEMMER_EP_DISABLE=coreml` (macOS) or disable the failing provider.
 - GPU forced for debugging but still bad output: remove `STEMMER_EP_FORCE` and let auto mode fallback.
 - Need detailed provider logs: set `DEBUG_STEMS=1`.
+- Need to retest a previously skipped GPU EP: use `STEMMER_EP_CACHE_BYPASS=1`.
+- Need to clear all remembered unhealthy EPs: use `STEMMER_EP_CACHE_RESET=1`.
 
 **Q: What's the quality compared to Python Demucs?**  
 A: Identical quality - we use the same model architecture, just optimized for ONNX.

--- a/README.md
+++ b/README.md
@@ -465,7 +465,31 @@ A: Yes! GPU acceleration is enabled by default and works across all platforms:
 - **Windows (any GPU)**: DirectML (NVIDIA, AMD, Intel)
 - **Intel**: oneDNN optimizations
 
-The library automatically detects available hardware and uses the best execution provider, falling back to CPU if no GPU is available. GPU mode significantly reduces CPU usage (~5x less) while maintaining similar processing speed.
+The library automatically detects available hardware, validates execution provider output during early inference, and falls back to CPU when a provider is unhealthy. This prevents "selected but silent" provider failures while keeping startup fast.
+
+You can control provider selection with environment variables:
+- `STEMMER_FORCE_CPU=1` — force CPU only
+- `STEMMER_EP_FORCE=cpu|cuda|coreml|directml|onednn` — force a specific provider (fails if unhealthy/unavailable)
+- `STEMMER_EP_DISABLE=coreml,directml,...` — disable providers from auto mode
+- `DEBUG_STEMS=1` — print provider selection and fallback diagnostics
+
+Optional ONNX Runtime thread tuning (advanced):
+- `STEMMER_ORT_INTRA_THREADS=<n>`
+- `STEMMER_ORT_INTER_THREADS=<n>`
+- `STEMMER_ORT_PARALLEL=0|1`
+
+**Q: GPU acceleration does not work on my machine. Can I skip it?**  
+A: Yes. If a provider is known to fail on your setup, disable it so it is not tried at all.
+
+Examples:
+- Skip CoreML on Apple Silicon (avoids repeated CoreML attempts):
+  - `STEMMER_EP_DISABLE=coreml cargo run --release --bin stem-splitter -- split --input song.mp3 --output ./out`
+- Force CPU-only mode (maximum stability):
+  - `STEMMER_FORCE_CPU=1 cargo run --release --bin stem-splitter -- split --input song.mp3 --output ./out`
+
+To apply this permanently in your shell:
+- `export STEMMER_EP_DISABLE=coreml`
+  (or `export STEMMER_FORCE_CPU=1`)
 
 **Q: What's the quality compared to Python Demucs?**  
 A: Identical quality - we use the same model architecture, just optimized for ONNX.

--- a/README.md
+++ b/README.md
@@ -464,12 +464,13 @@ A: Yes! GPU acceleration is enabled by default and works across all platforms:
 - **Apple Silicon**: CoreML (M1/M2/M3/M4 Macs)
 - **Windows (any GPU)**: DirectML (NVIDIA, AMD, Intel)
 - **Intel**: oneDNN optimizations
+- **ARM/x86 CPU fallback**: XNNPACK acceleration when GPU EPs are unavailable or unhealthy
 
 The library automatically detects available hardware, validates execution provider output during early inference, and falls back to CPU when a provider is unhealthy. Unhealthy providers are cached per machine/model for 7 days so future runs skip known-bad EPs and start faster.
 
 You can control provider selection with environment variables:
 - `STEMMER_FORCE_CPU=1` — force CPU only
-- `STEMMER_EP_FORCE=cpu|cuda|coreml|directml|onednn` — force a specific provider (fails if unhealthy/unavailable)
+- `STEMMER_EP_FORCE=cpu|cuda|coreml|directml|onednn|xnnpack` — force a specific provider (fails if unhealthy/unavailable)
 - `STEMMER_EP_DISABLE=coreml,directml,...` — disable providers from auto mode
 - `DEBUG_STEMS=1` — print provider selection and fallback diagnostics
 - `STEMMER_EP_CACHE_BYPASS=1` — ignore unhealthy EP cache for one run
@@ -480,12 +481,20 @@ Optional ONNX Runtime thread tuning (advanced):
 - `STEMMER_ORT_INTER_THREADS=<n>`
 - `STEMMER_ORT_PARALLEL=0|1`
 
+Optional CoreML tuning (advanced, macOS):
+- `STEMMER_COREML_UNITS=all|gpu|ane|cpu`
+- `STEMMER_COREML_MODEL_FORMAT=mlprogram|neuralnetwork`
+- `STEMMER_COREML_SPECIALIZATION=fastprediction|default`
+- `STEMMER_COREML_STATIC_INPUTS=0|1`
+
 **Q: GPU acceleration does not work on my machine. Can I skip it?**  
 A: Yes. If a provider is known to fail on your setup, disable it so it is not tried at all.
 
 Examples:
 - Skip CoreML on Apple Silicon (avoids repeated CoreML attempts):
   - `STEMMER_EP_DISABLE=coreml cargo run --release --bin stem-splitter -- split --input song.mp3 --output ./out`
+- Force XNNPACK on Apple Silicon for comparison testing:
+  - `STEMMER_EP_FORCE=xnnpack cargo run --release --bin stem-splitter -- split --input song.mp3 --output ./out`
 - Force CPU-only mode (maximum stability):
   - `STEMMER_FORCE_CPU=1 cargo run --release --bin stem-splitter -- split --input song.mp3 --output ./out`
 
@@ -494,7 +503,7 @@ To apply this permanently in your shell:
   (or `export STEMMER_FORCE_CPU=1`)
 
 Quick troubleshooting:
-- Silent stems or very low output with GPU: `STEMMER_EP_DISABLE=coreml` (macOS) or disable the failing provider.
+- Silent stems or very low output with GPU: `STEMMER_EP_DISABLE=coreml` on Apple Silicon so auto mode can fall through to XNNPACK.
 - GPU forced for debugging but still bad output: remove `STEMMER_EP_FORCE` and let auto mode fallback.
 - Need detailed provider logs: set `DEBUG_STEMS=1`.
 - Need to retest a previously skipped GPU EP: use `STEMMER_EP_CACHE_BYPASS=1`.

--- a/src/bin/stem-splitter.rs
+++ b/src/bin/stem-splitter.rs
@@ -1,6 +1,9 @@
 use clap::{Parser, Subcommand};
-use stem_splitter_core::{prepare_model, set_download_progress_callback, set_split_progress_callback, split_file, SplitOptions, SplitProgress};
 use std::process;
+use stem_splitter_core::{
+    prepare_model, set_download_progress_callback, set_split_progress_callback, split_file,
+    SplitOptions, SplitProgress,
+};
 
 #[derive(Parser)]
 #[command(name = "stem-splitter")]
@@ -16,38 +19,38 @@ enum Commands {
     Split {
         #[arg(short, long)]
         input: String,
-        
+
         #[arg(short, long, default_value = ".")]
         output: String,
-        
+
         #[arg(short, long, default_value = "htdemucs_ort_v1")]
         model: String,
-        
+
         #[arg(long)]
         manifest_url: Option<String>,
-        
+
         #[arg(short, long)]
         quiet: bool,
     },
-    
+
     Prepare {
         #[arg(short, long, default_value = "htdemucs_ort_v1")]
         model: String,
-        
+
         #[arg(long)]
         manifest_url: Option<String>,
-        
+
         #[arg(short, long)]
         quiet: bool,
     },
-    
+
     /// List available models
     List,
 }
 
 fn main() {
     let cli = Cli::parse();
-    
+
     let result = match cli.command {
         Commands::Split {
             input,
@@ -63,7 +66,7 @@ fn main() {
         } => handle_prepare(model, manifest_url, quiet),
         Commands::List => handle_list(),
     };
-    
+
     match result {
         Ok(()) => process::exit(0),
         Err(e) => {
@@ -83,17 +86,17 @@ fn handle_split(
     if !std::path::Path::new(&input).exists() {
         return Err(format!("Input file not found: {}", input).into());
     }
-    
+
     if !quiet {
         setup_progress_callbacks();
     }
-    
+
     let opts = SplitOptions {
         output_dir: output.clone(),
         model_name: model.clone(),
         manifest_url_override: manifest_url,
     };
-    
+
     if !quiet {
         eprintln!("🎵 Stem Splitter");
         eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
@@ -103,9 +106,9 @@ fn handle_split(
         eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
         eprintln!();
     }
-    
+
     let result = split_file(&input, opts)?;
-    
+
     if !quiet {
         eprintln!();
         eprintln!("✅ Split completed successfully!");
@@ -122,7 +125,7 @@ fn handle_split(
         println!("{}", result.bass_path);
         println!("{}", result.other_path);
     }
-    
+
     Ok(())
 }
 
@@ -134,7 +137,7 @@ fn handle_prepare(
     if !quiet {
         eprintln!("📦 Preparing model: {}", model);
         eprintln!();
-        
+
         set_download_progress_callback(|downloaded, total| {
             if total > 0 {
                 let percent = (downloaded as f64 / total as f64 * 100.0).round() as u64;
@@ -148,32 +151,36 @@ fn handle_prepare(
                     eprintln!();
                 }
             } else {
-                eprint!("\rDownloading model: {:.2} MB", downloaded as f64 / 1_000_000.0);
+                eprint!(
+                    "\rDownloading model: {:.2} MB",
+                    downloaded as f64 / 1_000_000.0
+                );
             }
         });
     }
-    
+
     prepare_model(&model, manifest_url.as_deref())?;
-    
+
     if !quiet {
         eprintln!("✅ Model prepared successfully!");
     }
-    
+
     Ok(())
 }
 
 fn handle_list() -> Result<(), Box<dyn std::error::Error>> {
     let registry_json = include_str!("../../models/registry.json");
     let registry: serde_json::Value = serde_json::from_str(registry_json)?;
-    
+
     eprintln!("📋 Available Models");
     eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-    
+
     if let Some(models) = registry.get("models").and_then(|m| m.as_array()) {
-        let default = registry.get("default")
+        let default = registry
+            .get("default")
             .and_then(|d| d.as_str())
             .unwrap_or("");
-        
+
         for model in models {
             if let Some(name) = model.get("name").and_then(|n| n.as_str()) {
                 let is_default = name == default;
@@ -182,10 +189,10 @@ fn handle_list() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     }
-    
+
     eprintln!();
     eprintln!("Use --model <name> to specify a model");
-    
+
     Ok(())
 }
 
@@ -203,10 +210,13 @@ fn setup_progress_callbacks() {
                 eprintln!();
             }
         } else {
-            eprint!("\r📥 Downloading model: {:.2} MB", downloaded as f64 / 1_000_000.0);
+            eprint!(
+                "\r📥 Downloading model: {:.2} MB",
+                downloaded as f64 / 1_000_000.0
+            );
         }
     });
-    
+
     set_split_progress_callback(|progress| {
         match progress {
             SplitProgress::Stage(stage) => {
@@ -226,7 +236,10 @@ fn setup_progress_callbacks() {
                 total,
                 percent,
             } => {
-                eprint!("\r🔄 Processing: {}/{} chunks ({:.0}%)", done, total, percent);
+                eprint!(
+                    "\r🔄 Processing: {}/{} chunks ({:.0}%)",
+                    done, total, percent
+                );
                 if done >= total {
                     eprintln!();
                 }
@@ -251,4 +264,3 @@ fn setup_progress_callbacks() {
         }
     });
 }
-

--- a/src/core/audio.rs
+++ b/src/core/audio.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, path::Path};
+use std::{fs::File, io::BufWriter, path::Path};
 
 use anyhow::{Context, Result};
 use symphonia::core::{
@@ -8,6 +8,8 @@ use symphonia::core::{
 use symphonia::default::{get_codecs, get_probe};
 
 use crate::types::AudioData;
+
+pub type WavWriter = hound::WavWriter<BufWriter<File>>;
 
 pub fn read_audio<P: AsRef<Path>>(path: P) -> Result<AudioData> {
     let path: &Path = path.as_ref();
@@ -68,24 +70,35 @@ pub fn read_audio<P: AsRef<Path>>(path: P) -> Result<AudioData> {
 }
 
 pub fn write_audio(path: &str, audio: &AudioData) -> Result<()> {
-    let path_obj = std::path::Path::new(path);
-    if let Some(parent) = path_obj.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-
-    let spec = hound::WavSpec {
-        channels: audio.channels,
-        sample_rate: audio.sample_rate,
-        bits_per_sample: 16,
-        sample_format: hound::SampleFormat::Int,
-    };
-
-    let mut writer = hound::WavWriter::create(path, spec)?;
+    let mut writer = create_wav_writer(path, audio.sample_rate, audio.channels)?;
     for sample in &audio.samples {
-        let s = (sample * i16::MAX as f32).clamp(i16::MIN as f32, i16::MAX as f32) as i16;
-        writer.write_sample(s)?;
+        writer.write_sample(sample_to_i16(*sample))?;
     }
 
     writer.finalize()?;
     Ok(())
+}
+
+pub fn create_wav_writer<P: AsRef<Path>>(
+    path: P,
+    sample_rate: u32,
+    channels: u16,
+) -> Result<WavWriter> {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let spec = hound::WavSpec {
+        channels,
+        sample_rate,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+
+    Ok(hound::WavWriter::create(path, spec)?)
+}
+
+pub fn sample_to_i16(sample: f32) -> i16 {
+    (sample * i16::MAX as f32).clamp(i16::MIN as f32, i16::MAX as f32) as i16
 }

--- a/src/core/dsp.rs
+++ b/src/core/dsp.rs
@@ -34,7 +34,7 @@ impl FftCache {
 
         // Need to create - use write lock
         let mut entries = self.entries.write().unwrap();
-        
+
         // Double-check after acquiring write lock
         if let Some(entry) = entries.get(&n_fft) {
             return Arc::clone(entry);
@@ -47,7 +47,7 @@ impl FftCache {
             fft_inverse: planner.plan_fft_inverse(n_fft),
             hann_window: compute_hann(n_fft),
         });
-        
+
         entries.insert(n_fft, Arc::clone(&entry));
         entry
     }
@@ -91,7 +91,7 @@ pub fn stft_cac_stereo_centered(
     hop: usize,
 ) -> (Vec<f32>, usize, usize) {
     assert_eq!(left.len(), right.len());
-    
+
     let t = left.len();
     let pad = n_fft / 2;
 
@@ -99,7 +99,7 @@ pub fn stft_cac_stereo_centered(
     let padded_len = pad + t + pad;
     let mut l_sig = vec![0.0f32; padded_len];
     let mut r_sig = vec![0.0f32; padded_len];
-    
+
     // Copy with padding
     l_sig[pad..pad + t].copy_from_slice(left);
     r_sig[pad..pad + t].copy_from_slice(right);
@@ -174,7 +174,7 @@ pub fn istft_cac_stereo(
     // Scratch buffers
     let mut buf_l = vec![Complex32::zero(); n_fft];
     let mut buf_r = vec![Complex32::zero(); n_fft];
-    
+
     let scale = 1.0 / (n_fft as f32);
 
     for fr in 0..frames {
@@ -257,7 +257,7 @@ pub fn istft_cac_stereo(
 
 /// Parallel iSTFT for multiple sources - processes all stems in parallel
 pub fn istft_cac_stereo_parallel(
-    sources_data: &[&[f32]],  // Slice of source spectrograms
+    sources_data: &[&[f32]], // Slice of source spectrograms
     f_bins: usize,
     frames: usize,
     n_fft: usize,
@@ -265,11 +265,9 @@ pub fn istft_cac_stereo_parallel(
     target_length: usize,
 ) -> Vec<(Vec<f32>, Vec<f32>)> {
     use rayon::prelude::*;
-    
+
     sources_data
         .par_iter()
-        .map(|spec_cac| {
-            istft_cac_stereo(spec_cac, f_bins, frames, n_fft, hop, target_length)
-        })
+        .map(|spec_cac| istft_cac_stereo(spec_cac, f_bins, frames, n_fft, hop, target_length))
         .collect()
 }

--- a/src/core/dsp.rs
+++ b/src/core/dsp.rs
@@ -1,5 +1,6 @@
 use num_complex::Complex32;
 use once_cell::sync::Lazy;
+use rayon::prelude::*;
 use rustfft::{num_traits::Zero, Fft, FftPlanner};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -84,38 +85,35 @@ pub fn to_planar_stereo(interleaved: &[f32], channels: u16) -> Vec<[f32; 2]> {
 /// Compute complex-as-channels spectrogram for stereo with center padding.
 /// Returns (buffer, F=n_fft/2, Frames) for given input.
 /// Layout is [1, 4, F, Frames] flattened => channels order: L.re, L.im, R.re, R.im.
-pub fn stft_cac_stereo_centered(
+pub(crate) fn stft_cac_stereo_centered_into(
     left: &[f32],
     right: &[f32],
     n_fft: usize,
     hop: usize,
-) -> (Vec<f32>, usize, usize) {
+    out: &mut Vec<f32>,
+) -> (usize, usize) {
     assert_eq!(left.len(), right.len());
 
     let t = left.len();
     let pad = n_fft / 2;
 
-    // Pre-allocate padded signals
     let padded_len = pad + t + pad;
     let mut l_sig = vec![0.0f32; padded_len];
     let mut r_sig = vec![0.0f32; padded_len];
 
-    // Copy with padding
     l_sig[pad..pad + t].copy_from_slice(left);
     r_sig[pad..pad + t].copy_from_slice(right);
 
     let frames = 1 + (t / hop);
     let f_bins = n_fft / 2;
 
-    // Get cached FFT and window
     let cache = FFT_CACHE.get_or_create(n_fft);
     let fft = &cache.fft_forward;
     let window = &cache.hann_window;
 
-    // Output buffer
-    let mut out = vec![0.0f32; 4 * f_bins * frames];
+    out.clear();
+    out.resize(4 * f_bins * frames, 0.0);
 
-    // Scratch buffers (reused across frames)
     let mut buf_l = vec![Complex32::zero(); n_fft];
     let mut buf_r = vec![Complex32::zero(); n_fft];
 
@@ -124,7 +122,6 @@ pub fn stft_cac_stereo_centered(
         let li = &l_sig[start..start + n_fft];
         let ri = &r_sig[start..start + n_fft];
 
-        // Window and pack into complex
         for i in 0..n_fft {
             let w = window[i];
             buf_l[i] = Complex32::new(li[i] * w, 0.0);
@@ -134,16 +131,233 @@ pub fn stft_cac_stereo_centered(
         fft.process(&mut buf_l);
         fft.process(&mut buf_r);
 
-        // Write channels [L.re, L.im, R.re, R.im] over [F,Frames]
         for fi in 0..f_bins {
             let base_fr = fi * frames + fr;
-            out[0 * f_bins * frames + base_fr] = buf_l[fi].re;
-            out[1 * f_bins * frames + base_fr] = buf_l[fi].im;
+            out[base_fr] = buf_l[fi].re;
+            out[f_bins * frames + base_fr] = buf_l[fi].im;
             out[2 * f_bins * frames + base_fr] = buf_r[fi].re;
             out[3 * f_bins * frames + base_fr] = buf_r[fi].im;
         }
     }
 
+    (f_bins, frames)
+}
+
+#[derive(Default)]
+pub(crate) struct IstftStereoWorkspace {
+    left_out: Vec<f32>,
+    right_out: Vec<f32>,
+    window_sum: Vec<f32>,
+    buf_l: Vec<Complex32>,
+    buf_r: Vec<Complex32>,
+}
+
+impl IstftStereoWorkspace {
+    fn ensure_capacity(&mut self, n_fft: usize, target_length: usize) {
+        let pad = n_fft / 2;
+        let padded_length = target_length + 2 * pad;
+
+        if self.left_out.len() != padded_length {
+            self.left_out.resize(padded_length, 0.0);
+            self.right_out.resize(padded_length, 0.0);
+            self.window_sum.resize(padded_length, 0.0);
+        }
+        if self.buf_l.len() != n_fft {
+            self.buf_l.resize(n_fft, Complex32::zero());
+            self.buf_r.resize(n_fft, Complex32::zero());
+        }
+    }
+
+    fn reset(&mut self) {
+        self.left_out.fill(0.0);
+        self.right_out.fill(0.0);
+        self.window_sum.fill(0.0);
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct IstftBatchWorkspace {
+    per_source: Vec<IstftStereoWorkspace>,
+}
+
+impl IstftBatchWorkspace {
+    pub(crate) fn ensure_sources(&mut self, num_sources: usize) {
+        if self.per_source.len() < num_sources {
+            self.per_source
+                .resize_with(num_sources, IstftStereoWorkspace::default);
+        }
+    }
+}
+
+fn istft_cac_stereo_reconstruct(
+    spec_cac: &[f32],
+    f_bins: usize,
+    frames: usize,
+    n_fft: usize,
+    hop: usize,
+    target_length: usize,
+    ws: &mut IstftStereoWorkspace,
+) -> (usize, usize) {
+    let cache = FFT_CACHE.get_or_create(n_fft);
+    let ifft = &cache.fft_inverse;
+    let window = &cache.hann_window;
+
+    let pad = n_fft / 2;
+    let padded_length = target_length + 2 * pad;
+    ws.ensure_capacity(n_fft, target_length);
+    ws.reset();
+
+    let scale = 1.0 / (n_fft as f32);
+
+    for fr in 0..frames {
+        ws.buf_l.fill(Complex32::zero());
+        ws.buf_r.fill(Complex32::zero());
+
+        for fi in 0..f_bins {
+            let base_fr = fi * frames + fr;
+            ws.buf_l[fi] = Complex32::new(spec_cac[base_fr], spec_cac[f_bins * frames + base_fr]);
+            ws.buf_r[fi] = Complex32::new(
+                spec_cac[2 * f_bins * frames + base_fr],
+                spec_cac[3 * f_bins * frames + base_fr],
+            );
+        }
+
+        for fi in 1..f_bins {
+            let neg_fi = n_fft - fi;
+            ws.buf_l[neg_fi] = ws.buf_l[fi].conj();
+            ws.buf_r[neg_fi] = ws.buf_r[fi].conj();
+        }
+
+        ws.buf_l[0].im = 0.0;
+        ws.buf_r[0].im = 0.0;
+        if n_fft % 2 == 0 && f_bins < n_fft {
+            ws.buf_l[n_fft / 2].im = 0.0;
+            ws.buf_r[n_fft / 2].im = 0.0;
+        }
+
+        ifft.process(&mut ws.buf_l);
+        ifft.process(&mut ws.buf_r);
+
+        let start = fr * hop;
+        for i in 0..n_fft {
+            let pos = start + i;
+            if pos < padded_length {
+                let w = window[i];
+                ws.left_out[pos] += ws.buf_l[i].re * w * scale;
+                ws.right_out[pos] += ws.buf_r[i].re * w * scale;
+                ws.window_sum[pos] += w * w;
+            }
+        }
+    }
+
+    for i in 0..padded_length {
+        let sum = ws.window_sum[i];
+        if sum > 1e-10 {
+            ws.left_out[i] /= sum;
+            ws.right_out[i] /= sum;
+        }
+    }
+
+    let start = pad.min(ws.left_out.len());
+    let end = (pad + target_length).min(ws.left_out.len());
+    (start, end)
+}
+
+pub(crate) fn istft_cac_stereo_into(
+    spec_cac: &[f32],
+    f_bins: usize,
+    frames: usize,
+    n_fft: usize,
+    hop: usize,
+    target_length: usize,
+    ws: &mut IstftStereoWorkspace,
+    left_dst: &mut [f32],
+    right_dst: &mut [f32],
+) {
+    assert_eq!(left_dst.len(), target_length);
+    assert_eq!(right_dst.len(), target_length);
+
+    let (start, end) =
+        istft_cac_stereo_reconstruct(spec_cac, f_bins, frames, n_fft, hop, target_length, ws);
+    let copy_len = end.saturating_sub(start);
+
+    if copy_len == target_length {
+        left_dst.copy_from_slice(&ws.left_out[start..end]);
+        right_dst.copy_from_slice(&ws.right_out[start..end]);
+    } else {
+        left_dst.fill(0.0);
+        right_dst.fill(0.0);
+        left_dst[..copy_len].copy_from_slice(&ws.left_out[start..end]);
+        right_dst[..copy_len].copy_from_slice(&ws.right_out[start..end]);
+    }
+}
+
+pub(crate) fn istft_cac_stereo_add_into(
+    spec_cac: &[f32],
+    f_bins: usize,
+    frames: usize,
+    n_fft: usize,
+    hop: usize,
+    target_length: usize,
+    ws: &mut IstftStereoWorkspace,
+    left_dst: &mut [f32],
+    right_dst: &mut [f32],
+) {
+    assert_eq!(left_dst.len(), target_length);
+    assert_eq!(right_dst.len(), target_length);
+
+    let (start, end) =
+        istft_cac_stereo_reconstruct(spec_cac, f_bins, frames, n_fft, hop, target_length, ws);
+
+    for (dst, value) in left_dst.iter_mut().zip(ws.left_out[start..end].iter()) {
+        *dst += *value;
+    }
+    for (dst, value) in right_dst.iter_mut().zip(ws.right_out[start..end].iter()) {
+        *dst += *value;
+    }
+}
+
+pub(crate) fn istft_cac_stereo_sources_add_into(
+    sources_data: &[&[f32]],
+    f_bins: usize,
+    frames: usize,
+    n_fft: usize,
+    hop: usize,
+    target_length: usize,
+    ws: &mut IstftBatchWorkspace,
+    dst: &mut [f32],
+) {
+    assert_eq!(dst.len(), sources_data.len() * 2 * target_length);
+
+    ws.ensure_sources(sources_data.len());
+    ws.per_source[..sources_data.len()]
+        .par_iter_mut()
+        .zip(sources_data.par_iter())
+        .zip(dst.par_chunks_mut(2 * target_length))
+        .for_each(|((workspace, spec_cac), chunk)| {
+            let (left_dst, right_dst) = chunk.split_at_mut(target_length);
+            istft_cac_stereo_add_into(
+                spec_cac,
+                f_bins,
+                frames,
+                n_fft,
+                hop,
+                target_length,
+                workspace,
+                left_dst,
+                right_dst,
+            );
+        });
+}
+
+pub fn stft_cac_stereo_centered(
+    left: &[f32],
+    right: &[f32],
+    n_fft: usize,
+    hop: usize,
+) -> (Vec<f32>, usize, usize) {
+    let mut out = Vec::new();
+    let (f_bins, frames) = stft_cac_stereo_centered_into(left, right, n_fft, hop, &mut out);
     (out, f_bins, frames)
 }
 
@@ -158,99 +372,20 @@ pub fn istft_cac_stereo(
     hop: usize,
     target_length: usize,
 ) -> (Vec<f32>, Vec<f32>) {
-    // Get cached IFFT and window
-    let cache = FFT_CACHE.get_or_create(n_fft);
-    let ifft = &cache.fft_inverse;
-    let window = &cache.hann_window;
-
-    let pad = n_fft / 2;
-    let padded_length = target_length + 2 * pad;
-
-    // Output buffers
-    let mut left_out = vec![0.0f32; padded_length];
-    let mut right_out = vec![0.0f32; padded_length];
-    let mut window_sum = vec![0.0f32; padded_length];
-
-    // Scratch buffers
-    let mut buf_l = vec![Complex32::zero(); n_fft];
-    let mut buf_r = vec![Complex32::zero(); n_fft];
-
-    let scale = 1.0 / (n_fft as f32);
-
-    for fr in 0..frames {
-        // Clear buffers
-        buf_l.fill(Complex32::zero());
-        buf_r.fill(Complex32::zero());
-
-        // Fill positive frequencies [0..f_bins]
-        for fi in 0..f_bins {
-            let base_fr = fi * frames + fr;
-            buf_l[fi] = Complex32::new(
-                spec_cac[0 * f_bins * frames + base_fr],
-                spec_cac[1 * f_bins * frames + base_fr],
-            );
-            buf_r[fi] = Complex32::new(
-                spec_cac[2 * f_bins * frames + base_fr],
-                spec_cac[3 * f_bins * frames + base_fr],
-            );
-        }
-
-        // Fill negative frequencies (complex conjugate mirror)
-        for fi in 1..f_bins {
-            let neg_fi = n_fft - fi;
-            buf_l[neg_fi] = buf_l[fi].conj();
-            buf_r[neg_fi] = buf_r[fi].conj();
-        }
-
-        // Ensure DC and Nyquist are real
-        buf_l[0].im = 0.0;
-        buf_r[0].im = 0.0;
-        if n_fft % 2 == 0 && f_bins < n_fft {
-            buf_l[n_fft / 2].im = 0.0;
-            buf_r[n_fft / 2].im = 0.0;
-        }
-
-        // Apply IFFT
-        ifft.process(&mut buf_l);
-        ifft.process(&mut buf_r);
-
-        // Overlap-add with window
-        let start = fr * hop;
-        for i in 0..n_fft {
-            let pos = start + i;
-            if pos < padded_length {
-                let w = window[i];
-                left_out[pos] += buf_l[i].re * w * scale;
-                right_out[pos] += buf_r[i].re * w * scale;
-                window_sum[pos] += w * w;
-            }
-        }
-    }
-
-    // Normalize by window sum
-    for i in 0..padded_length {
-        let sum = window_sum[i];
-        if sum > 1e-10 {
-            left_out[i] /= sum;
-            right_out[i] /= sum;
-        }
-    }
-
-    // Remove padding
-    let start = pad.min(left_out.len());
-    let end = (pad + target_length).min(left_out.len());
-
-    let left_final = if end > start {
-        left_out[start..end].to_vec()
-    } else {
-        vec![0.0; target_length]
-    };
-
-    let right_final = if end > start {
-        right_out[start..end].to_vec()
-    } else {
-        vec![0.0; target_length]
-    };
+    let mut ws = IstftStereoWorkspace::default();
+    let mut left_final = vec![0.0f32; target_length];
+    let mut right_final = vec![0.0f32; target_length];
+    istft_cac_stereo_into(
+        spec_cac,
+        f_bins,
+        frames,
+        n_fft,
+        hop,
+        target_length,
+        &mut ws,
+        &mut left_final,
+        &mut right_final,
+    );
 
     (left_final, right_final)
 }
@@ -264,10 +399,66 @@ pub fn istft_cac_stereo_parallel(
     hop: usize,
     target_length: usize,
 ) -> Vec<(Vec<f32>, Vec<f32>)> {
-    use rayon::prelude::*;
-
     sources_data
         .par_iter()
         .map(|spec_cac| istft_cac_stereo(spec_cac, f_bins, frames, n_fft, hop, target_length))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_abs_diff_eq;
+
+    #[test]
+    fn stft_into_matches_wrapper_output() {
+        let n_fft = 1024usize;
+        let hop = 256usize;
+        let t = 4096usize;
+        let left: Vec<f32> = (0..t).map(|i| (i as f32 * 0.01).sin()).collect();
+        let right: Vec<f32> = (0..t).map(|i| (i as f32 * 0.02).cos()).collect();
+
+        let (spec_a, f_bins_a, frames_a) = stft_cac_stereo_centered(&left, &right, n_fft, hop);
+        let mut spec_b = Vec::new();
+        let (f_bins_b, frames_b) =
+            stft_cac_stereo_centered_into(&left, &right, n_fft, hop, &mut spec_b);
+
+        assert_eq!(f_bins_a, f_bins_b);
+        assert_eq!(frames_a, frames_b);
+        assert_eq!(spec_a.len(), spec_b.len());
+        for (a, b) in spec_a.iter().zip(spec_b.iter()) {
+            assert_abs_diff_eq!(a, b, epsilon = 1e-7);
+        }
+    }
+
+    #[test]
+    fn istft_add_into_matches_wrapper_sum() {
+        let n_fft = 1024usize;
+        let hop = 256usize;
+        let t = 4096usize;
+        let left: Vec<f32> = (0..t).map(|i| (i as f32 * 0.013).sin() * 0.2).collect();
+        let right: Vec<f32> = (0..t).map(|i| (i as f32 * 0.017).cos() * 0.15).collect();
+        let (spec, f_bins, frames) = stft_cac_stereo_centered(&left, &right, n_fft, hop);
+        let (base_left, base_right) = istft_cac_stereo(&spec, f_bins, frames, n_fft, hop, t);
+
+        let mut ws = IstftStereoWorkspace::default();
+        let mut acc_left = vec![0.25f32; t];
+        let mut acc_right = vec![-0.5f32; t];
+        istft_cac_stereo_add_into(
+            &spec,
+            f_bins,
+            frames,
+            n_fft,
+            hop,
+            t,
+            &mut ws,
+            &mut acc_left,
+            &mut acc_right,
+        );
+
+        for i in 0..t {
+            assert_abs_diff_eq!(acc_left[i], 0.25 + base_left[i], epsilon = 1e-5);
+            assert_abs_diff_eq!(acc_right[i], -0.5 + base_right[i], epsilon = 1e-5);
+        }
+    }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -6,6 +6,7 @@ use crate::{
         ep,
     },
     error::{Result, StemError},
+    io::ep_cache,
     model::model_manager::ModelHandle,
     types::ModelManifest,
 };
@@ -46,6 +47,7 @@ const DEMUCS_HOP: usize = 1024;
 struct EngineContext {
     model_path: PathBuf,
     num_threads: usize,
+    selected_kind: ep::EpKind,
 }
 
 #[cfg(not(feature = "engine-mock"))]
@@ -307,7 +309,7 @@ pub fn preload(h: &ModelHandle) -> Result<()> {
         .map(|n| n.get())
         .unwrap_or(4);
 
-    let session = ep::create_best_session(
+    let selected = ep::create_best_session(
         h.local_path.as_path(),
         num_threads,
         commit_cpu_session,
@@ -319,11 +321,12 @@ pub fn preload(h: &ModelHandle) -> Result<()> {
         .set(EngineContext {
             model_path: h.local_path.clone(),
             num_threads,
+            selected_kind: selected.kind,
         })
         .ok();
     RUNTIME_EP_FALLBACK_USED.store(false, Ordering::Relaxed);
 
-    SESSION.set(Mutex::new(session)).ok();
+    SESSION.set(Mutex::new(selected.session)).ok();
     MANIFEST.set(h.manifest.clone()).ok();
     Ok(())
 }
@@ -442,6 +445,26 @@ pub fn run_window_demucs(left: &[f32], right: &[f32]) -> Result<Array3<f32>> {
             let ctx = ENGINE_CONTEXT
                 .get()
                 .ok_or_else(|| anyhow!("engine context missing for runtime fallback"))?;
+
+            if ctx.selected_kind != ep::EpKind::Cpu {
+                if let Err(cache_err) = ep_cache::mark_unhealthy(
+                    ctx.selected_kind.env_name(),
+                    &ctx.model_path,
+                    &error_text,
+                ) {
+                    if debug_enabled {
+                        eprintln!(
+                            "⚠️  Failed to persist unhealthy EP cache entry: {}",
+                            cache_err
+                        );
+                    }
+                } else if debug_enabled {
+                    eprintln!(
+                        "ℹ️  Marked {} as unhealthy for this model (cached for 7 days)",
+                        ctx.selected_kind.label()
+                    );
+                }
+            }
 
             if debug_enabled {
                 eprintln!(

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -339,6 +339,13 @@ pub fn manifest() -> &'static ModelManifest {
 const NEAR_SILENT_ERROR_PREFIX: &str = "near-silent execution output";
 
 #[cfg(not(feature = "engine-mock"))]
+enum RuntimeFallbackDecision {
+    RetryOnCpu,
+    ForcedProviderError,
+    PropagateOriginal,
+}
+
+#[cfg(not(feature = "engine-mock"))]
 fn output_is_near_silent(time_max: f32, freq_max: f32) -> bool {
     time_max < 1e-6 && freq_max < 1e-3
 }
@@ -361,6 +368,29 @@ fn is_forced_non_cpu_ep() -> bool {
 }
 
 #[cfg(not(feature = "engine-mock"))]
+fn near_silent_error(message: &str) -> bool {
+    message.contains(NEAR_SILENT_ERROR_PREFIX)
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn runtime_fallback_decision(
+    error_text: &str,
+    forced_non_cpu_ep: bool,
+    fallback_already_used: bool,
+) -> RuntimeFallbackDecision {
+    if !near_silent_error(error_text) {
+        return RuntimeFallbackDecision::PropagateOriginal;
+    }
+    if forced_non_cpu_ep {
+        return RuntimeFallbackDecision::ForcedProviderError;
+    }
+    if fallback_already_used {
+        return RuntimeFallbackDecision::PropagateOriginal;
+    }
+    RuntimeFallbackDecision::RetryOnCpu
+}
+
+#[cfg(not(feature = "engine-mock"))]
 pub fn run_window_demucs(left: &[f32], right: &[f32]) -> Result<Array3<f32>> {
     if left.len() != right.len() {
         return Err(anyhow!("L/R length mismatch").into());
@@ -379,17 +409,35 @@ pub fn run_window_demucs(left: &[f32], right: &[f32]) -> Result<Array3<f32>> {
 
     match run_window_demucs_with_session(&mut session, left, right, debug_enabled) {
         Ok(out) => Ok(out),
-        Err(e) if e.to_string().contains(NEAR_SILENT_ERROR_PREFIX) => {
-            if is_forced_non_cpu_ep() {
-                return Err(anyhow!(
-                    "Forced execution provider produced near-silent runtime output; refusing CPU fallback"
-                )
-                .into());
+        Err(e) => {
+            let error_text = e.to_string();
+            let forced_non_cpu_ep = is_forced_non_cpu_ep();
+            let fallback_already_used = RUNTIME_EP_FALLBACK_USED.load(Ordering::SeqCst);
+
+            match runtime_fallback_decision(&error_text, forced_non_cpu_ep, fallback_already_used) {
+                RuntimeFallbackDecision::ForcedProviderError => {
+                    if debug_enabled {
+                        eprintln!(
+                            "⚠️  Runtime EP output was near-silent and STEMMER_EP_FORCE is set; refusing CPU fallback"
+                        );
+                    }
+                    return Err(anyhow!(
+                        "Forced execution provider produced near-silent runtime output; refusing CPU fallback"
+                    )
+                    .into());
+                }
+                RuntimeFallbackDecision::PropagateOriginal => {
+                    if near_silent_error(&error_text) && debug_enabled {
+                        eprintln!(
+                            "⚠️  Runtime EP output remained near-silent after fallback; propagating original error"
+                        );
+                    }
+                    return Err(e);
+                }
+                RuntimeFallbackDecision::RetryOnCpu => {}
             }
 
-            if RUNTIME_EP_FALLBACK_USED.swap(true, Ordering::SeqCst) {
-                return Err(e);
-            }
+            RUNTIME_EP_FALLBACK_USED.store(true, Ordering::SeqCst);
 
             let ctx = ENGINE_CONTEXT
                 .get()
@@ -404,9 +452,21 @@ pub fn run_window_demucs(left: &[f32], right: &[f32]) -> Result<Array3<f32>> {
             let cpu_session = commit_cpu_session(&ctx.model_path, ctx.num_threads)?;
             *session = cpu_session;
 
-            run_window_demucs_with_session(&mut session, left, right, debug_enabled)
+            match run_window_demucs_with_session(&mut session, left, right, debug_enabled) {
+                Ok(out) => {
+                    if debug_enabled {
+                        eprintln!("✅ Runtime fallback succeeded: CPU is now active");
+                    }
+                    Ok(out)
+                }
+                Err(retry_error) => {
+                    if debug_enabled {
+                        eprintln!("❌ Runtime fallback to CPU failed: {}", retry_error);
+                    }
+                    Err(retry_error)
+                }
+            }
         }
-        Err(e) => Err(e),
     }
 }
 
@@ -493,6 +553,72 @@ fn run_window_demucs_with_session(
 
     let out = ndarray::Array3::from_shape_vec((num_sources, 2, t), result)?;
     Ok(out)
+}
+
+#[cfg(not(feature = "engine-mock"))]
+#[cfg(test)]
+mod runtime_policy_tests {
+    use super::*;
+
+    #[test]
+    fn fallback_retries_on_cpu_when_near_silent_and_not_forced() {
+        let decision = runtime_fallback_decision(
+            "near-silent execution output (time_max=0, freq_max=0)",
+            false,
+            false,
+        );
+        assert!(matches!(decision, RuntimeFallbackDecision::RetryOnCpu));
+    }
+
+    #[test]
+    fn fallback_refuses_when_forced_provider() {
+        let decision = runtime_fallback_decision(
+            "near-silent execution output (time_max=0, freq_max=0)",
+            true,
+            false,
+        );
+        assert!(matches!(
+            decision,
+            RuntimeFallbackDecision::ForcedProviderError
+        ));
+    }
+
+    #[test]
+    fn fallback_does_not_retry_twice() {
+        let decision = runtime_fallback_decision(
+            "near-silent execution output (time_max=0, freq_max=0)",
+            false,
+            true,
+        );
+        assert!(matches!(
+            decision,
+            RuntimeFallbackDecision::PropagateOriginal
+        ));
+    }
+
+    #[test]
+    fn fallback_ignores_non_silent_errors() {
+        let decision = runtime_fallback_decision("Model missing input 'x'", false, false);
+        assert!(matches!(
+            decision,
+            RuntimeFallbackDecision::PropagateOriginal
+        ));
+    }
+
+    #[test]
+    fn near_silent_threshold_checks() {
+        assert!(output_is_near_silent(1e-7, 1e-4));
+        assert!(!output_is_near_silent(1e-4, 1e-4));
+        assert!(!output_is_near_silent(1e-7, 1e-2));
+    }
+
+    #[test]
+    fn input_silence_threshold_checks() {
+        let quiet = vec![0.0f32; 16];
+        let loud = vec![5e-4f32; 16];
+        assert!(input_is_near_silent(&quiet, &quiet));
+        assert!(!input_is_near_silent(&loud, &quiet));
+    }
 }
 
 #[cfg(feature = "engine-mock")]

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -106,7 +106,10 @@ fn commit_session_sequential_eps(
 ) -> Result<Session> {
     if providers.is_empty() {
         if std::env::var("DEBUG_STEMS").is_ok() {
-            eprintln!("ℹ️  Using CPU ({} threads) - no GPU features enabled", num_threads);
+            eprintln!(
+                "ℹ️  Using CPU ({} threads) - no GPU features enabled",
+                num_threads
+            );
         }
         return commit_cpu_session(model_path, num_threads);
     }
@@ -152,16 +155,18 @@ fn commit_session_sequential_eps(
     }
 
     if std::env::var("DEBUG_STEMS").is_ok() {
-        eprintln!("⚠️  All EPs failed; falling back to CPU ({} threads)", num_threads);
+        eprintln!(
+            "⚠️  All EPs failed; falling back to CPU ({} threads)",
+            num_threads
+        );
     }
     commit_cpu_session(model_path, num_threads)
 }
 
-
 #[cfg(not(feature = "engine-mock"))]
 pub fn preload(h: &ModelHandle) -> Result<()> {
     ORT_INIT.get_or_try_init::<_, StemError>(|| {
-        ort::init().commit().map_err(StemError::from)?;
+        let _ = ort::init().commit();
         Ok(())
     })?;
 
@@ -251,17 +256,17 @@ pub fn run_window_demucs(left: &[f32], right: &[f32]) -> Result<Array3<f32>> {
 
     // Get input names
     let in_time = session
-        .inputs
+        .inputs()
         .iter()
-        .find(|i| i.name == "input")
-        .map(|i| i.name.clone())
+        .find(|i| i.name() == "input")
+        .map(|i| i.name().to_owned())
         .ok_or_else(|| anyhow!("Model missing input 'input'"))?;
 
     let in_spec = session
-        .inputs
+        .inputs()
         .iter()
-        .find(|i| i.name == "x")
-        .map(|i| i.name.clone())
+        .find(|i| i.name() == "x")
+        .map(|i| i.name().to_owned())
         .ok_or_else(|| anyhow!("Model missing input 'x'"))?;
 
     // Run inference

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -2,7 +2,9 @@
 
 use crate::{
     core::{
-        dsp::{istft_cac_stereo_parallel, stft_cac_stereo_centered},
+        dsp::{
+            istft_cac_stereo_sources_add_into, stft_cac_stereo_centered_into, IstftBatchWorkspace,
+        },
         ep,
     },
     error::{Result, StemError},
@@ -19,7 +21,7 @@ use ort::{
         builder::{GraphOptimizationLevel, SessionBuilder},
         Session,
     },
-    value::{Tensor, Value},
+    value::{TensorRef, Value},
 };
 use std::{
     path::PathBuf,
@@ -27,11 +29,22 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Mutex,
     },
+    time::Instant,
 };
 
 static SESSION: OnceCell<Mutex<Session>> = OnceCell::new();
 static MANIFEST: OnceCell<ModelManifest> = OnceCell::new();
 static ORT_INIT: OnceCell<()> = OnceCell::new();
+#[cfg(not(feature = "engine-mock"))]
+static ENGINE_IO_SPEC: OnceCell<EngineIoSpec> = OnceCell::new();
+#[cfg(not(feature = "engine-mock"))]
+static ENGINE_PERF: OnceCell<EnginePerfConfig> = OnceCell::new();
+#[cfg(not(feature = "engine-mock"))]
+static INPUT_SCRATCH: OnceCell<Mutex<InferenceScratch>> = OnceCell::new();
+#[cfg(not(feature = "engine-mock"))]
+static ISTFT_SCRATCH: OnceCell<Mutex<IstftBatchWorkspace>> = OnceCell::new();
+#[cfg(not(feature = "engine-mock"))]
+static PRELOAD_PROBE_INPUT: OnceCell<(Vec<f32>, Vec<f32>)> = OnceCell::new();
 #[cfg(not(feature = "engine-mock"))]
 static ENGINE_CONTEXT: OnceCell<EngineContext> = OnceCell::new();
 #[cfg(not(feature = "engine-mock"))]
@@ -65,6 +78,55 @@ struct OrtThreading {
     intra_threads: usize,
     inter_threads: usize,
     parallel_execution: bool,
+}
+
+#[cfg(not(feature = "engine-mock"))]
+#[derive(Clone, Copy)]
+struct EngineIoSpec {
+    use_positional_inputs: bool,
+}
+
+#[cfg(not(feature = "engine-mock"))]
+#[derive(Clone, Copy)]
+struct EnginePerfConfig {
+    enabled: bool,
+}
+
+#[cfg(not(feature = "engine-mock"))]
+#[derive(Default)]
+struct WindowPerf {
+    prep_ns: u128,
+    stft_ns: u128,
+    lock_wait_ns: u128,
+    run_ns: u128,
+    extract_ns: u128,
+    decode_ns: u128,
+    istft_ns: u128,
+    mix_ns: u128,
+    total_ns: u128,
+}
+
+#[cfg(not(feature = "engine-mock"))]
+#[derive(Default)]
+struct InferenceScratch {
+    time_branch: Vec<f32>,
+    spec_branch: Vec<f32>,
+}
+
+#[cfg(not(feature = "engine-mock"))]
+impl InferenceScratch {
+    fn with_demucs_capacity() -> Self {
+        Self {
+            time_branch: Vec::with_capacity(2 * DEMUCS_T),
+            spec_branch: Vec::with_capacity(4 * DEMUCS_F * DEMUCS_FRAMES),
+        }
+    }
+
+    fn fill_time_branch(&mut self, left: &[f32], right: &[f32]) {
+        self.time_branch.clear();
+        self.time_branch.extend_from_slice(left);
+        self.time_branch.extend_from_slice(right);
+    }
 }
 
 #[cfg(not(feature = "engine-mock"))]
@@ -103,6 +165,77 @@ fn apply_thread_overrides(mut cfg: OrtThreading) -> OrtThreading {
 }
 
 #[cfg(not(feature = "engine-mock"))]
+fn perf_config() -> &'static EnginePerfConfig {
+    ENGINE_PERF.get_or_init(|| EnginePerfConfig {
+        enabled: std::env::var("STEMMER_PERF").is_ok(),
+    })
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn input_scratch() -> &'static Mutex<InferenceScratch> {
+    INPUT_SCRATCH.get_or_init(|| Mutex::new(InferenceScratch::with_demucs_capacity()))
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn istft_scratch() -> &'static Mutex<IstftBatchWorkspace> {
+    ISTFT_SCRATCH.get_or_init(|| Mutex::new(IstftBatchWorkspace::default()))
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn io_spec() -> &'static EngineIoSpec {
+    ENGINE_IO_SPEC
+        .get()
+        .expect("engine::preload() must initialize input binding")
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn use_positional_inputs(input_names: &[&str]) -> bool {
+    matches!(input_names, ["input", "x"])
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn inspect_engine_io(session: &Session) -> Result<EngineIoSpec> {
+    let input_names: Vec<&str> = session.inputs().iter().map(|input| input.name()).collect();
+    let output_names: Vec<&str> = session
+        .outputs()
+        .iter()
+        .map(|output| output.name())
+        .collect();
+
+    if !output_names.contains(&"output") {
+        return Err(anyhow!("Model missing output 'output' (freq domain)").into());
+    }
+    if !output_names.contains(&"add_67") {
+        return Err(anyhow!("Model missing output 'add_67' (time domain)").into());
+    }
+
+    Ok(EngineIoSpec {
+        use_positional_inputs: use_positional_inputs(&input_names),
+    })
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn format_ms(ns: u128) -> f64 {
+    ns as f64 / 1_000_000.0
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn log_window_perf(perf: &WindowPerf) {
+    eprintln!(
+        "⏱️  window total={:.2}ms prep={:.2}ms stft={:.2}ms lock={:.2}ms run={:.2}ms extract={:.2}ms decode={:.2}ms istft={:.2}ms mix={:.2}ms",
+        format_ms(perf.total_ns),
+        format_ms(perf.prep_ns),
+        format_ms(perf.stft_ns),
+        format_ms(perf.lock_wait_ns),
+        format_ms(perf.run_ns),
+        format_ms(perf.extract_ns),
+        format_ms(perf.decode_ns),
+        format_ms(perf.istft_ns),
+        format_ms(perf.mix_ns),
+    );
+}
+
+#[cfg(not(feature = "engine-mock"))]
 fn cpu_threading(num_threads: usize) -> OrtThreading {
     let base = OrtThreading {
         intra_threads: num_threads.max(1),
@@ -122,6 +255,11 @@ fn ep_threading(kind: ep::EpKind, num_threads: usize) -> OrtThreading {
         },
         ep::EpKind::OneDNN | ep::EpKind::Cpu => OrtThreading {
             intra_threads: num_threads.max(1),
+            inter_threads: 1,
+            parallel_execution: false,
+        },
+        ep::EpKind::Xnnpack => OrtThreading {
+            intra_threads: 1,
             inter_threads: 1,
             parallel_execution: false,
         },
@@ -164,12 +302,18 @@ fn commit_ep_session(
         );
     }
 
-    let builder = SessionBuilder::new()?
+    let mut builder = SessionBuilder::new()?
         .with_optimization_level(GraphOptimizationLevel::Level3)?
         .with_intra_threads(threading.intra_threads)?
         .with_inter_threads(threading.inter_threads)?
         .with_parallel_execution(threading.parallel_execution)?
         .with_execution_providers(vec![provider])?;
+
+    if matches!(kind, ep::EpKind::Xnnpack) {
+        builder = builder
+            .with_intra_op_spinning(false)?
+            .with_inter_op_spinning(false)?;
+    }
 
     Ok(builder.commit_from_file(model_path)?)
 }
@@ -177,47 +321,53 @@ fn commit_ep_session(
 #[cfg(not(feature = "engine-mock"))]
 fn run_demucs_raw_from_inputs(
     session: &mut Session,
+    io_spec: &EngineIoSpec,
     t: usize,
     f_bins: usize,
     frames: usize,
-    time_branch: Vec<f32>,
-    spec_branch: Vec<f32>,
-) -> Result<DemucsRawOutput> {
-    let time_value: Value = Tensor::from_array((vec![1, 2, t], time_branch))?.into_dyn();
-    let spec_value: Value =
-        Tensor::from_array((vec![1, 4, f_bins, frames], spec_branch))?.into_dyn();
+    time_branch: &[f32],
+    spec_branch: &[f32],
+    perf_enabled: bool,
+    perf: &mut WindowPerf,
+) -> Result<(Value, Value)> {
+    let time_value = TensorRef::from_array_view(([1usize, 2, t], time_branch))?;
+    let spec_value = TensorRef::from_array_view(([1usize, 4, f_bins, frames], spec_branch))?;
 
-    let in_time = session
-        .inputs()
-        .iter()
-        .find(|i| i.name() == "input")
-        .map(|i| i.name().to_owned())
-        .ok_or_else(|| anyhow!("Model missing input 'input'"))?;
-
-    let in_spec = session
-        .inputs()
-        .iter()
-        .find(|i| i.name() == "x")
-        .map(|i| i.name().to_owned())
-        .ok_or_else(|| anyhow!("Model missing input 'x'"))?;
-
-    let outputs = session.run(vec![(in_time, time_value), (in_spec, spec_value)])?;
-
-    let mut output_freq: Option<Value> = None;
-    let mut output_time: Option<Value> = None;
-
-    for (name, val) in outputs.into_iter() {
-        if name == "output" {
-            output_freq = Some(val);
-        } else if name == "add_67" {
-            output_time = Some(val);
-        }
+    let run_start = perf_enabled.then(Instant::now);
+    let mut outputs = if io_spec.use_positional_inputs {
+        session.run(ort::inputs![time_value, spec_value])?
+    } else {
+        session.run(ort::inputs!["input" => time_value, "x" => spec_value])?
+    };
+    if let Some(start) = run_start {
+        perf.run_ns += start.elapsed().as_nanos();
     }
 
-    let out_freq =
-        output_freq.ok_or_else(|| anyhow!("Model did not return 'output' (freq domain)"))?;
-    let out_time =
-        output_time.ok_or_else(|| anyhow!("Model did not return 'add_67' (time domain)"))?;
+    let extract_start = perf_enabled.then(Instant::now);
+    let out_freq = outputs
+        .remove("output")
+        .ok_or_else(|| anyhow!("Model did not return 'output' (freq domain)"))?;
+    let out_time = outputs
+        .remove("add_67")
+        .ok_or_else(|| anyhow!("Model did not return 'add_67' (time domain)"))?;
+    if let Some(start) = extract_start {
+        perf.extract_ns += start.elapsed().as_nanos();
+    }
+
+    Ok((out_time, out_freq))
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn decode_demucs_outputs(
+    out_time: Value,
+    out_freq: Value,
+    t: usize,
+    f_bins: usize,
+    frames: usize,
+    perf_enabled: bool,
+    perf: &mut WindowPerf,
+) -> Result<DemucsRawOutput> {
+    let decode_start = perf_enabled.then(Instant::now);
 
     let (shape_time, data_time) = out_time.try_extract_tensor::<f32>()?;
     if shape_time.len() != 4
@@ -255,21 +405,29 @@ fn run_demucs_raw_from_inputs(
     let time_max = data_time.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
     let freq_max = data_freq.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
 
-    Ok(DemucsRawOutput {
+    let raw = DemucsRawOutput {
         num_sources,
         data_time: data_time.to_vec(),
         data_freq: data_freq.to_vec(),
         time_max,
         freq_max,
-    })
+    };
+
+    if let Some(start) = decode_start {
+        perf.decode_ns += start.elapsed().as_nanos();
+    }
+
+    Ok(raw)
 }
 
 #[cfg(not(feature = "engine-mock"))]
-fn run_demucs_raw_with_session(
-    session: &mut Session,
+fn prepare_demucs_inputs(
     left: &[f32],
     right: &[f32],
-) -> Result<DemucsRawOutput> {
+    scratch: &mut InferenceScratch,
+    perf_enabled: bool,
+    perf: &mut WindowPerf,
+) -> Result<(usize, usize, usize)> {
     if left.len() != right.len() {
         return Err(anyhow!("L/R length mismatch").into());
     }
@@ -278,12 +436,20 @@ fn run_demucs_raw_with_session(
         return Err(anyhow!("Bad window length {} (expected {})", t, DEMUCS_T).into());
     }
 
-    let mut time_branch = Vec::with_capacity(2 * t);
-    time_branch.extend_from_slice(left);
-    time_branch.extend_from_slice(right);
+    let prep_start = perf_enabled.then(Instant::now);
+    scratch.fill_time_branch(left, right);
 
-    let (spec_branch, f_bins, frames) =
-        stft_cac_stereo_centered(left, right, DEMUCS_NFFT, DEMUCS_HOP);
+    let stft_start = perf_enabled.then(Instant::now);
+    let (f_bins, frames) = stft_cac_stereo_centered_into(
+        left,
+        right,
+        DEMUCS_NFFT,
+        DEMUCS_HOP,
+        &mut scratch.spec_branch,
+    );
+    if let Some(start) = stft_start {
+        perf.stft_ns += start.elapsed().as_nanos();
+    }
     if f_bins != DEMUCS_F || frames != DEMUCS_FRAMES {
         return Err(anyhow!(
             "Spec dims mismatch: got F={},Frames={}, expected F={},Frames={}",
@@ -295,7 +461,36 @@ fn run_demucs_raw_with_session(
         .into());
     }
 
-    run_demucs_raw_from_inputs(session, t, f_bins, frames, time_branch, spec_branch)
+    if let Some(start) = prep_start {
+        perf.prep_ns += start.elapsed().as_nanos();
+    }
+
+    Ok((t, f_bins, frames))
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn run_demucs_raw_with_session(
+    session: &mut Session,
+    io_spec: &EngineIoSpec,
+    scratch: &mut InferenceScratch,
+    left: &[f32],
+    right: &[f32],
+    perf_enabled: bool,
+    perf: &mut WindowPerf,
+) -> Result<DemucsRawOutput> {
+    let (t, f_bins, frames) = prepare_demucs_inputs(left, right, scratch, perf_enabled, perf)?;
+    let (out_time, out_freq) = run_demucs_raw_from_inputs(
+        session,
+        io_spec,
+        t,
+        f_bins,
+        frames,
+        &scratch.time_branch,
+        &scratch.spec_branch,
+        perf_enabled,
+        perf,
+    )?;
+    decode_demucs_outputs(out_time, out_freq, t, f_bins, frames, perf_enabled, perf)
 }
 
 #[cfg(not(feature = "engine-mock"))]
@@ -314,8 +509,29 @@ pub fn preload(h: &ModelHandle) -> Result<()> {
         num_threads,
         commit_cpu_session,
         commit_ep_session,
-        |_| Ok(()),
+        probe_session_health,
     )?;
+
+    let selected_io = inspect_engine_io(&selected.session)?;
+    ENGINE_IO_SPEC.set(selected_io).ok();
+    ENGINE_PERF.set(*perf_config()).ok();
+    INPUT_SCRATCH
+        .set(Mutex::new(InferenceScratch::with_demucs_capacity()))
+        .ok();
+    ISTFT_SCRATCH
+        .set(Mutex::new(IstftBatchWorkspace::default()))
+        .ok();
+
+    if std::env::var("DEBUG_STEMS").is_ok() {
+        eprintln!(
+            "ℹ️  Engine input binding: {}",
+            if selected_io.use_positional_inputs {
+                "positional"
+            } else {
+                "named"
+            }
+        );
+    }
 
     ENGINE_CONTEXT
         .set(EngineContext {
@@ -361,6 +577,65 @@ fn input_is_near_silent(left: &[f32], right: &[f32]) -> bool {
 }
 
 #[cfg(not(feature = "engine-mock"))]
+fn build_preload_probe_input() -> (Vec<f32>, Vec<f32>) {
+    use std::f32::consts::TAU;
+
+    let sample_rate = 44_100.0f32;
+    let mut left = Vec::with_capacity(DEMUCS_T);
+    let mut right = Vec::with_capacity(DEMUCS_T);
+
+    for i in 0..DEMUCS_T {
+        let t = i as f32 / sample_rate;
+        left.push(0.22 * (TAU * 220.0 * t).sin() + 0.11 * (TAU * 660.0 * t).sin());
+        right.push(0.20 * (TAU * 330.0 * t).sin() + 0.09 * (TAU * 880.0 * t).cos());
+    }
+
+    (left, right)
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn preload_probe_input() -> &'static (Vec<f32>, Vec<f32>) {
+    PRELOAD_PROBE_INPUT.get_or_init(build_preload_probe_input)
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn ensure_output_is_not_near_silent(
+    left: &[f32],
+    right: &[f32],
+    raw: &DemucsRawOutput,
+) -> Result<()> {
+    if !input_is_near_silent(left, right) && output_is_near_silent(raw.time_max, raw.freq_max) {
+        return Err(anyhow!(
+            "{} (time_max={:.3e}, freq_max={:.3e})",
+            NEAR_SILENT_ERROR_PREFIX,
+            raw.time_max,
+            raw.freq_max
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn probe_session_health(session: &mut Session) -> Result<()> {
+    let (left, right) = preload_probe_input();
+    let io_spec = inspect_engine_io(session)?;
+    let mut scratch = InferenceScratch::with_demucs_capacity();
+    let mut perf = WindowPerf::default();
+    let raw = run_demucs_raw_with_session(
+        session,
+        &io_spec,
+        &mut scratch,
+        left,
+        right,
+        false,
+        &mut perf,
+    )?;
+    ensure_output_is_not_near_silent(left, right, &raw)
+}
+
+#[cfg(not(feature = "engine-mock"))]
 fn is_forced_non_cpu_ep() -> bool {
     let Ok(value) = std::env::var("STEMMER_EP_FORCE") else {
         return false;
@@ -402,15 +677,10 @@ pub fn run_window_demucs(left: &[f32], right: &[f32]) -> Result<Array3<f32>> {
         return Err(anyhow!("Bad window length {} (expected {})", left.len(), DEMUCS_T).into());
     }
 
-    let mut session = SESSION
-        .get()
-        .expect("engine::preload first")
-        .lock()
-        .expect("session poisoned");
-
     let debug_enabled = std::env::var("DEBUG_STEMS").is_ok();
+    let perf_enabled = perf_config().enabled;
 
-    match run_window_demucs_with_session(&mut session, left, right, debug_enabled) {
+    match run_window_demucs_once(left, right, debug_enabled, perf_enabled) {
         Ok(out) => Ok(out),
         Err(e) => {
             let error_text = e.to_string();
@@ -473,9 +743,15 @@ pub fn run_window_demucs(left: &[f32], right: &[f32]) -> Result<Array3<f32>> {
             }
 
             let cpu_session = commit_cpu_session(&ctx.model_path, ctx.num_threads)?;
+            let mut session = SESSION
+                .get()
+                .expect("engine::preload first")
+                .lock()
+                .expect("session poisoned");
             *session = cpu_session;
+            drop(session);
 
-            match run_window_demucs_with_session(&mut session, left, right, debug_enabled) {
+            match run_window_demucs_once(left, right, debug_enabled, perf_enabled) {
                 Ok(out) => {
                     if debug_enabled {
                         eprintln!("✅ Runtime fallback succeeded: CPU is now active");
@@ -494,24 +770,77 @@ pub fn run_window_demucs(left: &[f32], right: &[f32]) -> Result<Array3<f32>> {
 }
 
 #[cfg(not(feature = "engine-mock"))]
-fn run_window_demucs_with_session(
-    session: &mut Session,
+fn run_window_demucs_once(
     left: &[f32],
     right: &[f32],
     debug_enabled: bool,
+    perf_enabled: bool,
 ) -> Result<Array3<f32>> {
-    if left.len() != right.len() {
-        return Err(anyhow!("L/R length mismatch").into());
-    }
-    let t = left.len();
-    if t != DEMUCS_T {
-        return Err(anyhow!("Bad window length {} (expected {})", t, DEMUCS_T).into());
+    let total_start = perf_enabled.then(Instant::now);
+    let mut perf = WindowPerf::default();
+
+    let raw = {
+        let mut scratch = input_scratch().lock().expect("input scratch poisoned");
+        let (t, f_bins, frames) =
+            prepare_demucs_inputs(left, right, &mut scratch, perf_enabled, &mut perf)?;
+
+        let lock_start = perf_enabled.then(Instant::now);
+        let mut session = SESSION
+            .get()
+            .expect("engine::preload first")
+            .lock()
+            .expect("session poisoned");
+        if let Some(start) = lock_start {
+            perf.lock_wait_ns += start.elapsed().as_nanos();
+        }
+
+        let (out_time, out_freq) = run_demucs_raw_from_inputs(
+            &mut session,
+            io_spec(),
+            t,
+            f_bins,
+            frames,
+            &scratch.time_branch,
+            &scratch.spec_branch,
+            perf_enabled,
+            &mut perf,
+        )?;
+        drop(session);
+        drop(scratch);
+
+        decode_demucs_outputs(
+            out_time,
+            out_freq,
+            t,
+            f_bins,
+            frames,
+            perf_enabled,
+            &mut perf,
+        )?
+    };
+
+    let out = postprocess_demucs_output(raw, left, right, debug_enabled, perf_enabled, &mut perf)?;
+
+    if let Some(start) = total_start {
+        perf.total_ns = start.elapsed().as_nanos();
+        log_window_perf(&perf);
     }
 
-    let raw = run_demucs_raw_with_session(session, left, right)?;
+    Ok(out)
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn postprocess_demucs_output(
+    mut raw: DemucsRawOutput,
+    left: &[f32],
+    right: &[f32],
+    debug_enabled: bool,
+    perf_enabled: bool,
+    perf: &mut WindowPerf,
+) -> Result<Array3<f32>> {
+    let t = left.len();
     let num_sources = raw.num_sources;
 
-    // Debug: Check if model outputs are non-zero
     if debug_enabled {
         eprintln!(
             "Model output stats: time_max={:.6}, freq_max={:.6}",
@@ -519,15 +848,7 @@ fn run_window_demucs_with_session(
         );
     }
 
-    if !input_is_near_silent(left, right) && output_is_near_silent(raw.time_max, raw.freq_max) {
-        return Err(anyhow!(
-            "{} (time_max={:.3e}, freq_max={:.3e})",
-            NEAR_SILENT_ERROR_PREFIX,
-            raw.time_max,
-            raw.freq_max
-        )
-        .into());
-    }
+    ensure_output_is_not_near_silent(left, right, &raw)?;
 
     let source_specs: Vec<&[f32]> = (0..num_sources)
         .map(|src| {
@@ -536,46 +857,48 @@ fn run_window_demucs_with_session(
         })
         .collect();
 
-    let istft_results = istft_cac_stereo_parallel(
-        &source_specs,
-        DEMUCS_F,
-        DEMUCS_FRAMES,
-        DEMUCS_NFFT,
-        DEMUCS_HOP,
-        t,
-    );
+    let istft_start = perf_enabled.then(Instant::now);
+    {
+        let mut istft_ws = istft_scratch().lock().expect("iSTFT scratch poisoned");
+        istft_cac_stereo_sources_add_into(
+            &source_specs,
+            DEMUCS_F,
+            DEMUCS_FRAMES,
+            DEMUCS_NFFT,
+            DEMUCS_HOP,
+            t,
+            &mut istft_ws,
+            &mut raw.data_time,
+        );
+    }
+    if let Some(start) = istft_start {
+        perf.istft_ns += start.elapsed().as_nanos();
+    }
 
-    // Debug: Check iSTFT results
     if debug_enabled {
-        for (src_idx, (left, right)) in istft_results.iter().enumerate() {
-            let left_max = left.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
-            let right_max = right.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
+        for src_idx in 0..num_sources {
+            let src_time_offset = src_idx * 2 * t;
+            let left_mix = &raw.data_time[src_time_offset..src_time_offset + t];
+            let right_mix = &raw.data_time[src_time_offset + t..src_time_offset + 2 * t];
+            let left_max = left_mix.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
+            let right_max = right_mix.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
             eprintln!(
-                "iSTFT result [source {}]: left_max={:.6}, right_max={:.6}",
+                "Combined output [source {}]: left_max={:.6}, right_max={:.6}",
                 src_idx, left_max, right_max
             );
         }
     }
 
-    let mut result = Vec::with_capacity(num_sources * 2 * t);
+    let mix_start = perf_enabled.then(Instant::now);
 
-    for (src, (left_freq, right_freq)) in istft_results.into_iter().enumerate() {
-        // Extract time domain for this source [2, T]
-        let src_time_offset = src * 2 * t;
-        let left_time = &raw.data_time[src_time_offset..src_time_offset + t];
-        let right_time = &raw.data_time[src_time_offset + t..src_time_offset + 2 * t];
-
-        // Combine: output = time_domain + frequency_domain (after iSTFT)
-        for i in 0..t {
-            result.push(left_time[i] + left_freq[i]);
-        }
-        for i in 0..t {
-            result.push(right_time[i] + right_freq[i]);
-        }
+    if let Some(start) = mix_start {
+        perf.mix_ns += start.elapsed().as_nanos();
     }
 
-    let out = ndarray::Array3::from_shape_vec((num_sources, 2, t), result)?;
-    Ok(out)
+    Ok(ndarray::Array3::from_shape_vec(
+        (num_sources, 2, t),
+        raw.data_time,
+    )?)
 }
 
 #[cfg(not(feature = "engine-mock"))]
@@ -641,6 +964,21 @@ mod runtime_policy_tests {
         let loud = vec![5e-4f32; 16];
         assert!(input_is_near_silent(&quiet, &quiet));
         assert!(!input_is_near_silent(&loud, &quiet));
+    }
+
+    #[test]
+    fn preload_probe_input_is_loud_enough_for_health_checks() {
+        let (left, right) = build_preload_probe_input();
+        assert_eq!(left.len(), DEMUCS_T);
+        assert_eq!(right.len(), DEMUCS_T);
+        assert!(!input_is_near_silent(&left, &right));
+    }
+
+    #[test]
+    fn positional_binding_detection_requires_expected_input_order() {
+        assert!(use_positional_inputs(&["input", "x"]));
+        assert!(!use_positional_inputs(&["x", "input"]));
+        assert!(!use_positional_inputs(&["input"]));
     }
 }
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -1,7 +1,10 @@
 #![cfg_attr(feature = "engine-mock", allow(dead_code, unused_imports))]
 
 use crate::{
-    core::dsp::{istft_cac_stereo_parallel, stft_cac_stereo_centered},
+    core::{
+        dsp::{istft_cac_stereo_parallel, stft_cac_stereo_centered},
+        ep,
+    },
     error::{Result, StemError},
     model::model_manager::ModelHandle,
     types::ModelManifest,
@@ -11,31 +14,27 @@ use anyhow::anyhow;
 use ndarray::Array3;
 use once_cell::sync::OnceCell;
 use ort::{
-    execution_providers::ExecutionProviderDispatch,
     session::{
         builder::{GraphOptimizationLevel, SessionBuilder},
         Session,
     },
     value::{Tensor, Value},
 };
-use std::sync::Mutex;
-
-// CUDA: Linux and Windows only
-#[cfg(all(feature = "cuda", any(target_os = "linux", target_os = "windows")))]
-use ort::execution_providers::CUDAExecutionProvider;
-// CoreML: macOS only (Apple Silicon)
-#[cfg(all(feature = "coreml", target_os = "macos"))]
-use ort::execution_providers::CoreMLExecutionProvider;
-// DirectML: Windows only
-#[cfg(all(feature = "directml", target_os = "windows"))]
-use ort::execution_providers::DirectMLExecutionProvider;
-// oneDNN: All platforms
-#[cfg(feature = "onednn")]
-use ort::execution_providers::OneDNNExecutionProvider;
+use std::{
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Mutex,
+    },
+};
 
 static SESSION: OnceCell<Mutex<Session>> = OnceCell::new();
 static MANIFEST: OnceCell<ModelManifest> = OnceCell::new();
 static ORT_INIT: OnceCell<()> = OnceCell::new();
+#[cfg(not(feature = "engine-mock"))]
+static ENGINE_CONTEXT: OnceCell<EngineContext> = OnceCell::new();
+#[cfg(not(feature = "engine-mock"))]
+static RUNTIME_EP_FALLBACK_USED: AtomicBool = AtomicBool::new(false);
 
 const DEMUCS_T: usize = 343_980;
 const DEMUCS_F: usize = 2048;
@@ -43,218 +42,149 @@ const DEMUCS_FRAMES: usize = 336;
 const DEMUCS_NFFT: usize = 4096;
 const DEMUCS_HOP: usize = 1024;
 
-#[allow(unused_mut)]
-fn get_execution_providers() -> Vec<ExecutionProviderDispatch> {
-    let mut providers: Vec<ExecutionProviderDispatch> = Vec::new();
+#[cfg(not(feature = "engine-mock"))]
+struct EngineContext {
+    model_path: PathBuf,
+    num_threads: usize,
+}
 
-    #[cfg(all(feature = "cuda", any(target_os = "linux", target_os = "windows")))]
-    {
-        providers.push(CUDAExecutionProvider::default().build());
+#[cfg(not(feature = "engine-mock"))]
+struct DemucsRawOutput {
+    num_sources: usize,
+    data_time: Vec<f32>,
+    data_freq: Vec<f32>,
+    time_max: f32,
+    freq_max: f32,
+}
+
+#[cfg(not(feature = "engine-mock"))]
+#[derive(Clone, Copy)]
+struct OrtThreading {
+    intra_threads: usize,
+    inter_threads: usize,
+    parallel_execution: bool,
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn parse_env_usize(name: &str) -> Option<usize> {
+    let raw = std::env::var(name).ok()?;
+    let parsed = raw.parse::<usize>().ok()?;
+    if parsed == 0 {
+        None
+    } else {
+        Some(parsed)
     }
+}
 
-    #[cfg(all(feature = "coreml", target_os = "macos"))]
-    {
-        // CoreML can sometimes produce silent/zero outputs on certain models
-        // Only enable if ENABLE_COREML env var is set
-        if std::env::var("ENABLE_COREML").is_ok() {
-            if std::env::var("DEBUG_STEMS").is_ok() {
-                eprintln!("ℹ️  CoreML enabled via ENABLE_COREML environment variable");
-            }
-            providers.push(CoreMLExecutionProvider::default().build());
-        } else if std::env::var("DEBUG_STEMS").is_ok() {
-            eprintln!("ℹ️  CoreML disabled by default (set ENABLE_COREML=1 to enable)");
-        }
+#[cfg(not(feature = "engine-mock"))]
+fn parse_env_bool(name: &str) -> Option<bool> {
+    let raw = std::env::var(name).ok()?;
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
     }
+}
 
-    #[cfg(all(feature = "directml", target_os = "windows"))]
-    {
-        // DirectML can fail on some models/drivers (init errors). Keep it opt-in.
-        if std::env::var("ENABLE_DIRECTML").is_ok() {
-            if std::env::var("DEBUG_STEMS").is_ok() {
-                eprintln!("ℹ️  DirectML enabled via ENABLE_DIRECTML environment variable");
-            }
-            providers.push(DirectMLExecutionProvider::default().build());
-        } else if std::env::var("DEBUG_STEMS").is_ok() {
-            eprintln!("ℹ️  DirectML disabled by default (set ENABLE_DIRECTML=1 to enable)");
-        }
+#[cfg(not(feature = "engine-mock"))]
+fn apply_thread_overrides(mut cfg: OrtThreading) -> OrtThreading {
+    if let Some(intra) = parse_env_usize("STEMMER_ORT_INTRA_THREADS") {
+        cfg.intra_threads = intra;
     }
-
-    #[cfg(feature = "onednn")]
-    {
-        // oneDNN can improve performance on Intel CPUs
-        providers.push(OneDNNExecutionProvider::default().build());
+    if let Some(inter) = parse_env_usize("STEMMER_ORT_INTER_THREADS") {
+        cfg.inter_threads = inter;
     }
+    if let Some(parallel) = parse_env_bool("STEMMER_ORT_PARALLEL") {
+        cfg.parallel_execution = parallel;
+    }
+    cfg
+}
 
-    providers
+#[cfg(not(feature = "engine-mock"))]
+fn cpu_threading(num_threads: usize) -> OrtThreading {
+    let base = OrtThreading {
+        intra_threads: num_threads.max(1),
+        inter_threads: 1,
+        parallel_execution: false,
+    };
+    apply_thread_overrides(base)
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn ep_threading(kind: ep::EpKind, num_threads: usize) -> OrtThreading {
+    let base = match kind {
+        ep::EpKind::Cuda | ep::EpKind::CoreML | ep::EpKind::DirectML => OrtThreading {
+            intra_threads: num_threads.clamp(1, 4),
+            inter_threads: 1,
+            parallel_execution: false,
+        },
+        ep::EpKind::OneDNN | ep::EpKind::Cpu => OrtThreading {
+            intra_threads: num_threads.max(1),
+            inter_threads: 1,
+            parallel_execution: false,
+        },
+    };
+    apply_thread_overrides(base)
 }
 
 #[cfg(not(feature = "engine-mock"))]
 fn commit_cpu_session(model_path: &std::path::Path, num_threads: usize) -> Result<Session> {
+    let threading = cpu_threading(num_threads);
+
+    if std::env::var("DEBUG_STEMS").is_ok() {
+        eprintln!(
+            "ℹ️  ORT CPU threading: intra={}, inter={}, parallel={}",
+            threading.intra_threads, threading.inter_threads, threading.parallel_execution
+        );
+    }
+
     Ok(SessionBuilder::new()?
         .with_optimization_level(GraphOptimizationLevel::Level3)?
-        .with_intra_threads(num_threads)?
-        .with_inter_threads(num_threads)?
-        .with_parallel_execution(true)?
+        .with_intra_threads(threading.intra_threads)?
+        .with_inter_threads(threading.inter_threads)?
+        .with_parallel_execution(threading.parallel_execution)?
         .commit_from_file(model_path)?)
 }
 
 #[cfg(not(feature = "engine-mock"))]
-fn commit_session_sequential_eps(
+fn commit_ep_session(
     model_path: &std::path::Path,
     num_threads: usize,
-    providers: Vec<ExecutionProviderDispatch>,
+    kind: ep::EpKind,
+    provider: ort::execution_providers::ExecutionProviderDispatch,
 ) -> Result<Session> {
-    if providers.is_empty() {
-        if std::env::var("DEBUG_STEMS").is_ok() {
-            eprintln!(
-                "ℹ️  Using CPU ({} threads) - no GPU features enabled",
-                num_threads
-            );
-        }
-        return commit_cpu_session(model_path, num_threads);
-    }
+    let threading = ep_threading(kind, num_threads);
 
     if std::env::var("DEBUG_STEMS").is_ok() {
         eprintln!(
-            "ℹ️  Trying execution providers sequentially ({} candidates) with CPU fallback",
-            providers.len()
+            "ℹ️  ORT EP threading: intra={}, inter={}, parallel={}",
+            threading.intra_threads, threading.inter_threads, threading.parallel_execution
         );
     }
 
-    for (idx, ep) in providers.into_iter().enumerate() {
-        let builder_res = SessionBuilder::new()?
-            .with_optimization_level(GraphOptimizationLevel::Level3)?
-            .with_intra_threads(num_threads)?
-            .with_inter_threads(num_threads)?
-            .with_execution_providers(vec![ep]);
+    let builder = SessionBuilder::new()?
+        .with_optimization_level(GraphOptimizationLevel::Level3)?
+        .with_intra_threads(threading.intra_threads)?
+        .with_inter_threads(threading.inter_threads)?
+        .with_parallel_execution(threading.parallel_execution)?
+        .with_execution_providers(vec![provider])?;
 
-        let builder = match builder_res {
-            Ok(b) => b,
-            Err(e) => {
-                if std::env::var("DEBUG_STEMS").is_ok() {
-                    eprintln!("⚠️  EP builder failed (attempt #{}): {}", idx + 1, e);
-                }
-                continue;
-            }
-        };
-
-        match builder.commit_from_file(model_path) {
-            Ok(sess) => {
-                if std::env::var("DEBUG_STEMS").is_ok() {
-                    eprintln!("✅ Execution provider selected (attempt #{}).", idx + 1);
-                }
-                return Ok(sess);
-            }
-            Err(e) => {
-                if std::env::var("DEBUG_STEMS").is_ok() {
-                    eprintln!("⚠️  EP commit failed (attempt #{}): {}", idx + 1, e);
-                }
-                continue;
-            }
-        }
-    }
-
-    if std::env::var("DEBUG_STEMS").is_ok() {
-        eprintln!(
-            "⚠️  All EPs failed; falling back to CPU ({} threads)",
-            num_threads
-        );
-    }
-    commit_cpu_session(model_path, num_threads)
+    Ok(builder.commit_from_file(model_path)?)
 }
 
 #[cfg(not(feature = "engine-mock"))]
-pub fn preload(h: &ModelHandle) -> Result<()> {
-    ORT_INIT.get_or_try_init::<_, StemError>(|| {
-        let _ = ort::init().commit();
-        Ok(())
-    })?;
+fn run_demucs_raw_from_inputs(
+    session: &mut Session,
+    t: usize,
+    f_bins: usize,
+    frames: usize,
+    time_branch: Vec<f32>,
+    spec_branch: Vec<f32>,
+) -> Result<DemucsRawOutput> {
+    let time_value: Value = Tensor::from_array((vec![1, 2, t], time_branch))?.into_dyn();
+    let spec_value: Value =
+        Tensor::from_array((vec![1, 4, f_bins, frames], spec_branch))?.into_dyn();
 
-    let num_threads = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(4);
-
-    // Debug / escape hatch: force CPU
-    if std::env::var("STEMMER_FORCE_CPU").is_ok() {
-        if std::env::var("DEBUG_STEMS").is_ok() {
-            eprintln!("ℹ️  STEMMER_FORCE_CPU is set: using CPU only");
-        }
-        let session = commit_cpu_session(h.local_path.as_path(), num_threads)?;
-        SESSION.set(Mutex::new(session)).ok();
-        MANIFEST.set(h.manifest.clone()).ok();
-        return Ok(());
-    }
-
-    // Build provider list (may be empty)
-    let providers = get_execution_providers();
-
-    // Optional: print provider list names (for logs)
-    #[allow(unused_mut)]
-    let mut provider_names: Vec<&str> = Vec::new();
-    #[cfg(all(feature = "cuda", any(target_os = "linux", target_os = "windows")))]
-    provider_names.push("CUDA");
-    #[cfg(all(feature = "coreml", target_os = "macos"))]
-    provider_names.push("CoreML");
-    #[cfg(all(feature = "directml", target_os = "windows"))]
-    provider_names.push("DirectML (opt-in)");
-    #[cfg(feature = "onednn")]
-    provider_names.push("oneDNN");
-
-    if std::env::var("DEBUG_STEMS").is_ok() {
-        eprintln!("ℹ️  Configured EP candidates: {:?}", provider_names);
-    }
-
-    let session = commit_session_sequential_eps(h.local_path.as_path(), num_threads, providers)?;
-
-    SESSION.set(Mutex::new(session)).ok();
-    MANIFEST.set(h.manifest.clone()).ok();
-    Ok(())
-}
-
-#[cfg(not(feature = "engine-mock"))]
-pub fn manifest() -> &'static ModelManifest {
-    MANIFEST
-        .get()
-        .expect("engine::preload() must be called once before using the engine")
-}
-
-#[cfg(not(feature = "engine-mock"))]
-pub fn run_window_demucs(left: &[f32], right: &[f32]) -> Result<Array3<f32>> {
-    if left.len() != right.len() {
-        return Err(anyhow!("L/R length mismatch").into());
-    }
-    let t = left.len();
-    if t != DEMUCS_T {
-        return Err(anyhow!("Bad window length {} (expected {})", t, DEMUCS_T).into());
-    }
-
-    // Build time branch [1,2,T], planar
-    let mut planar = Vec::with_capacity(2 * t);
-    planar.extend_from_slice(left);
-    planar.extend_from_slice(right);
-    let time_value: Value = Tensor::from_array((vec![1, 2, t], planar))?.into_dyn();
-
-    // Build spec branch [1,4,F,Frames] with center padding, Hann, 4096/1024
-    let (spec_cac, f_bins, frames) = stft_cac_stereo_centered(left, right, DEMUCS_NFFT, DEMUCS_HOP);
-    if f_bins != DEMUCS_F || frames != DEMUCS_FRAMES {
-        return Err(anyhow!(
-            "Spec dims mismatch: got F={},Frames={}, expected F={},Frames={}",
-            f_bins,
-            frames,
-            DEMUCS_F,
-            DEMUCS_FRAMES
-        )
-        .into());
-    }
-    let spec_value: Value = Tensor::from_array((vec![1, 4, f_bins, frames], spec_cac))?.into_dyn();
-
-    let mut session = SESSION
-        .get()
-        .expect("engine::preload first")
-        .lock()
-        .expect("session poisoned");
-
-    // Get input names
     let in_time = session
         .inputs()
         .iter()
@@ -269,12 +199,8 @@ pub fn run_window_demucs(left: &[f32], right: &[f32]) -> Result<Array3<f32>> {
         .map(|i| i.name().to_owned())
         .ok_or_else(|| anyhow!("Model missing input 'x'"))?;
 
-    // Run inference
     let outputs = session.run(vec![(in_time, time_value), (in_spec, spec_value)])?;
 
-    // Extract both outputs from the model
-    // "output": frequency domain [1, sources, 4, F, Frames]
-    // "add_67": time domain [1, sources, 2, T]
     let mut output_freq: Option<Value> = None;
     let mut output_time: Option<Value> = None;
 
@@ -291,28 +217,24 @@ pub fn run_window_demucs(left: &[f32], right: &[f32]) -> Result<Array3<f32>> {
     let out_time =
         output_time.ok_or_else(|| anyhow!("Model did not return 'add_67' (time domain)"))?;
 
-    // Extract time domain output [1, 4, 2, T] -> [4, 2, T]
     let (shape_time, data_time) = out_time.try_extract_tensor::<f32>()?;
+    if shape_time.len() != 4
+        || shape_time[0] != 1
+        || shape_time[2] != 2
+        || shape_time[3] != t as i64
+    {
+        return Err(anyhow!(
+            "Unexpected time output shape: {:?}, expected [1, sources, 2, {}]",
+            shape_time,
+            t
+        )
+        .into());
+    }
     let num_sources = shape_time[1] as usize;
 
-    // Extract frequency domain output [1, sources, 4, F, Frames]
     let (shape_freq, data_freq) = out_freq.try_extract_tensor::<f32>()?;
-
-    // Debug: Check if model outputs are non-zero
-    if std::env::var("DEBUG_STEMS").is_ok() {
-        let time_max = data_time.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
-        let freq_max = data_freq.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
-        eprintln!(
-            "Model output stats: time_max={:.6}, freq_max={:.6}",
-            time_max, freq_max
-        );
-        if time_max < 1e-10 && freq_max < 1e-10 {
-            eprintln!("WARNING: Model outputs are all zeros! This indicates a problem with the execution provider.");
-        }
-    }
-
-    // Validate shapes
-    if shape_freq[0] != 1
+    if shape_freq.len() != 5
+        || shape_freq[0] != 1
         || shape_freq[1] != num_sources as i64
         || shape_freq[2] != 4
         || shape_freq[3] != f_bins as i64
@@ -328,18 +250,220 @@ pub fn run_window_demucs(left: &[f32], right: &[f32]) -> Result<Array3<f32>> {
         .into());
     }
 
+    let time_max = data_time.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
+    let freq_max = data_freq.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
+
+    Ok(DemucsRawOutput {
+        num_sources,
+        data_time: data_time.to_vec(),
+        data_freq: data_freq.to_vec(),
+        time_max,
+        freq_max,
+    })
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn run_demucs_raw_with_session(
+    session: &mut Session,
+    left: &[f32],
+    right: &[f32],
+) -> Result<DemucsRawOutput> {
+    if left.len() != right.len() {
+        return Err(anyhow!("L/R length mismatch").into());
+    }
+    let t = left.len();
+    if t != DEMUCS_T {
+        return Err(anyhow!("Bad window length {} (expected {})", t, DEMUCS_T).into());
+    }
+
+    let mut time_branch = Vec::with_capacity(2 * t);
+    time_branch.extend_from_slice(left);
+    time_branch.extend_from_slice(right);
+
+    let (spec_branch, f_bins, frames) =
+        stft_cac_stereo_centered(left, right, DEMUCS_NFFT, DEMUCS_HOP);
+    if f_bins != DEMUCS_F || frames != DEMUCS_FRAMES {
+        return Err(anyhow!(
+            "Spec dims mismatch: got F={},Frames={}, expected F={},Frames={}",
+            f_bins,
+            frames,
+            DEMUCS_F,
+            DEMUCS_FRAMES
+        )
+        .into());
+    }
+
+    run_demucs_raw_from_inputs(session, t, f_bins, frames, time_branch, spec_branch)
+}
+
+#[cfg(not(feature = "engine-mock"))]
+pub fn preload(h: &ModelHandle) -> Result<()> {
+    ORT_INIT.get_or_try_init::<_, StemError>(|| {
+        let _ = ort::init().commit();
+        Ok(())
+    })?;
+
+    let num_threads = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+
+    let session = ep::create_best_session(
+        h.local_path.as_path(),
+        num_threads,
+        commit_cpu_session,
+        commit_ep_session,
+        |_| Ok(()),
+    )?;
+
+    ENGINE_CONTEXT
+        .set(EngineContext {
+            model_path: h.local_path.clone(),
+            num_threads,
+        })
+        .ok();
+    RUNTIME_EP_FALLBACK_USED.store(false, Ordering::Relaxed);
+
+    SESSION.set(Mutex::new(session)).ok();
+    MANIFEST.set(h.manifest.clone()).ok();
+    Ok(())
+}
+
+#[cfg(not(feature = "engine-mock"))]
+pub fn manifest() -> &'static ModelManifest {
+    MANIFEST
+        .get()
+        .expect("engine::preload() must be called once before using the engine")
+}
+
+#[cfg(not(feature = "engine-mock"))]
+const NEAR_SILENT_ERROR_PREFIX: &str = "near-silent execution output";
+
+#[cfg(not(feature = "engine-mock"))]
+fn output_is_near_silent(time_max: f32, freq_max: f32) -> bool {
+    time_max < 1e-6 && freq_max < 1e-3
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn input_is_near_silent(left: &[f32], right: &[f32]) -> bool {
+    let left_max = left.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
+    let right_max = right.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
+    left_max.max(right_max) < 1e-4
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn is_forced_non_cpu_ep() -> bool {
+    let Ok(value) = std::env::var("STEMMER_EP_FORCE") else {
+        return false;
+    };
+
+    let v = value.trim().to_ascii_lowercase();
+    !v.is_empty() && v != "cpu"
+}
+
+#[cfg(not(feature = "engine-mock"))]
+pub fn run_window_demucs(left: &[f32], right: &[f32]) -> Result<Array3<f32>> {
+    if left.len() != right.len() {
+        return Err(anyhow!("L/R length mismatch").into());
+    }
+    if left.len() != DEMUCS_T {
+        return Err(anyhow!("Bad window length {} (expected {})", left.len(), DEMUCS_T).into());
+    }
+
+    let mut session = SESSION
+        .get()
+        .expect("engine::preload first")
+        .lock()
+        .expect("session poisoned");
+
+    let debug_enabled = std::env::var("DEBUG_STEMS").is_ok();
+
+    match run_window_demucs_with_session(&mut session, left, right, debug_enabled) {
+        Ok(out) => Ok(out),
+        Err(e) if e.to_string().contains(NEAR_SILENT_ERROR_PREFIX) => {
+            if is_forced_non_cpu_ep() {
+                return Err(anyhow!(
+                    "Forced execution provider produced near-silent runtime output; refusing CPU fallback"
+                )
+                .into());
+            }
+
+            if RUNTIME_EP_FALLBACK_USED.swap(true, Ordering::SeqCst) {
+                return Err(e);
+            }
+
+            let ctx = ENGINE_CONTEXT
+                .get()
+                .ok_or_else(|| anyhow!("engine context missing for runtime fallback"))?;
+
+            if debug_enabled {
+                eprintln!(
+                    "⚠️  Runtime EP output was near-silent; switching to CPU and retrying this chunk"
+                );
+            }
+
+            let cpu_session = commit_cpu_session(&ctx.model_path, ctx.num_threads)?;
+            *session = cpu_session;
+
+            run_window_demucs_with_session(&mut session, left, right, debug_enabled)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(not(feature = "engine-mock"))]
+fn run_window_demucs_with_session(
+    session: &mut Session,
+    left: &[f32],
+    right: &[f32],
+    debug_enabled: bool,
+) -> Result<Array3<f32>> {
+    if left.len() != right.len() {
+        return Err(anyhow!("L/R length mismatch").into());
+    }
+    let t = left.len();
+    if t != DEMUCS_T {
+        return Err(anyhow!("Bad window length {} (expected {})", t, DEMUCS_T).into());
+    }
+
+    let raw = run_demucs_raw_with_session(session, left, right)?;
+    let num_sources = raw.num_sources;
+
+    // Debug: Check if model outputs are non-zero
+    if debug_enabled {
+        eprintln!(
+            "Model output stats: time_max={:.6}, freq_max={:.6}",
+            raw.time_max, raw.freq_max
+        );
+    }
+
+    if !input_is_near_silent(left, right) && output_is_near_silent(raw.time_max, raw.freq_max) {
+        return Err(anyhow!(
+            "{} (time_max={:.3e}, freq_max={:.3e})",
+            NEAR_SILENT_ERROR_PREFIX,
+            raw.time_max,
+            raw.freq_max
+        )
+        .into());
+    }
+
     let source_specs: Vec<&[f32]> = (0..num_sources)
         .map(|src| {
-            let src_freq_offset = src * 4 * f_bins * frames;
-            &data_freq[src_freq_offset..src_freq_offset + 4 * f_bins * frames]
+            let src_freq_offset = src * 4 * DEMUCS_F * DEMUCS_FRAMES;
+            &raw.data_freq[src_freq_offset..src_freq_offset + 4 * DEMUCS_F * DEMUCS_FRAMES]
         })
         .collect();
 
-    let istft_results =
-        istft_cac_stereo_parallel(&source_specs, f_bins, frames, DEMUCS_NFFT, DEMUCS_HOP, t);
+    let istft_results = istft_cac_stereo_parallel(
+        &source_specs,
+        DEMUCS_F,
+        DEMUCS_FRAMES,
+        DEMUCS_NFFT,
+        DEMUCS_HOP,
+        t,
+    );
 
     // Debug: Check iSTFT results
-    if std::env::var("DEBUG_STEMS").is_ok() {
+    if debug_enabled {
         for (src_idx, (left, right)) in istft_results.iter().enumerate() {
             let left_max = left.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
             let right_max = right.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
@@ -355,8 +479,8 @@ pub fn run_window_demucs(left: &[f32], right: &[f32]) -> Result<Array3<f32>> {
     for (src, (left_freq, right_freq)) in istft_results.into_iter().enumerate() {
         // Extract time domain for this source [2, T]
         let src_time_offset = src * 2 * t;
-        let left_time = &data_time[src_time_offset..src_time_offset + t];
-        let right_time = &data_time[src_time_offset + t..src_time_offset + 2 * t];
+        let left_time = &raw.data_time[src_time_offset..src_time_offset + t];
+        let right_time = &raw.data_time[src_time_offset + t..src_time_offset + 2 * t];
 
         // Combine: output = time_domain + frequency_domain (after iSTFT)
         for i in 0..t {

--- a/src/core/ep.rs
+++ b/src/core/ep.rs
@@ -1,0 +1,481 @@
+#![cfg_attr(feature = "engine-mock", allow(dead_code))]
+
+use crate::error::Result;
+
+use anyhow::anyhow;
+use ort::{
+    execution_providers::{ExecutionProvider, ExecutionProviderDispatch},
+    session::Session,
+};
+use std::path::Path;
+
+// CUDA: Linux and Windows only
+#[cfg(all(feature = "cuda", any(target_os = "linux", target_os = "windows")))]
+use ort::execution_providers::CUDAExecutionProvider;
+// CoreML: macOS only (Apple Silicon)
+#[cfg(all(feature = "coreml", target_os = "macos"))]
+use ort::execution_providers::CoreMLExecutionProvider;
+// DirectML: Windows only
+#[cfg(all(feature = "directml", target_os = "windows"))]
+use ort::execution_providers::DirectMLExecutionProvider;
+// oneDNN: x86 Linux/Windows only
+#[cfg(feature = "onednn")]
+use ort::execution_providers::OneDNNExecutionProvider;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum EpKind {
+    Cpu,
+    Cuda,
+    CoreML,
+    DirectML,
+    OneDNN,
+}
+
+impl EpKind {
+    fn label(self) -> &'static str {
+        match self {
+            EpKind::Cpu => "CPU",
+            EpKind::Cuda => "CUDA",
+            EpKind::CoreML => "CoreML",
+            EpKind::DirectML => "DirectML",
+            EpKind::OneDNN => "oneDNN",
+        }
+    }
+
+    fn env_name(self) -> &'static str {
+        match self {
+            EpKind::Cpu => "cpu",
+            EpKind::Cuda => "cuda",
+            EpKind::CoreML => "coreml",
+            EpKind::DirectML => "directml",
+            EpKind::OneDNN => "onednn",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct EpRequest {
+    kinds: Vec<EpKind>,
+    forced_kind: Option<EpKind>,
+    force_cpu: bool,
+}
+
+#[derive(Debug)]
+struct EpCandidate {
+    kind: EpKind,
+    dispatch: ExecutionProviderDispatch,
+}
+
+impl EpCandidate {
+    fn name(&self) -> &'static str {
+        self.kind.label()
+    }
+}
+
+pub(crate) fn create_best_session<FCpu, FEp, FProbe>(
+    model_path: &Path,
+    num_threads: usize,
+    mut build_cpu_session: FCpu,
+    mut build_ep_session: FEp,
+    mut probe_session: FProbe,
+) -> Result<Session>
+where
+    FCpu: FnMut(&Path, usize) -> Result<Session>,
+    FEp: FnMut(&Path, usize, EpKind, ExecutionProviderDispatch) -> Result<Session>,
+    FProbe: FnMut(&mut Session) -> Result<()>,
+{
+    let debug_enabled = is_debug_enabled();
+    let request = resolve_ep_request_from_env()?;
+
+    if request.force_cpu {
+        if debug_enabled {
+            eprintln!(
+                "ℹ️  CPU mode forced by environment (STEMMER_FORCE_CPU or STEMMER_EP_FORCE=cpu)"
+            );
+        }
+        if debug_enabled {
+            eprintln!("✅ Execution provider selected: CPU");
+        }
+        return build_cpu_session(model_path, num_threads);
+    }
+
+    if let Some(kind) = request.forced_kind {
+        if debug_enabled {
+            eprintln!("ℹ️  Forcing execution provider: {}", kind.label());
+        }
+    }
+
+    let mut providers: Vec<EpCandidate> = Vec::new();
+    for kind in request.kinds {
+        match try_build_execution_provider(kind) {
+            Ok(dispatch) => providers.push(EpCandidate { kind, dispatch }),
+            Err(reason) => {
+                if request.forced_kind == Some(kind) {
+                    return Err(anyhow!(
+                        "Failed to activate forced execution provider '{}': {}",
+                        kind.env_name(),
+                        reason
+                    )
+                    .into());
+                }
+
+                if debug_enabled {
+                    eprintln!("ℹ️  Skipping {}: {}", kind.label(), reason);
+                }
+            }
+        }
+    }
+
+    if debug_enabled {
+        let provider_names: Vec<&str> = providers.iter().map(EpCandidate::name).collect();
+        eprintln!("ℹ️  Configured EP candidates: {:?}", provider_names);
+    }
+
+    if debug_enabled && !providers.is_empty() {
+        eprintln!(
+            "ℹ️  Trying execution providers sequentially ({} candidates) with CPU fallback",
+            providers.len()
+        );
+    }
+
+    for (idx, candidate) in providers.into_iter().enumerate() {
+        let ep_name = candidate.name();
+        let mut session =
+            match build_ep_session(model_path, num_threads, candidate.kind, candidate.dispatch) {
+                Ok(session) => session,
+                Err(e) => {
+                    if request.forced_kind == Some(candidate.kind) {
+                        return Err(anyhow!(
+                            "Failed to create forced execution provider '{}': {}",
+                            candidate.kind.env_name(),
+                            e
+                        )
+                        .into());
+                    }
+                    if debug_enabled {
+                        eprintln!(
+                            "⚠️  EP commit failed for {} (attempt #{}): {}",
+                            ep_name,
+                            idx + 1,
+                            e
+                        );
+                    }
+                    continue;
+                }
+            };
+
+        match probe_session(&mut session) {
+            Ok(()) => {
+                if debug_enabled {
+                    eprintln!(
+                        "✅ Execution provider selected: {} (attempt #{})",
+                        ep_name,
+                        idx + 1
+                    );
+                }
+                return Ok(session);
+            }
+            Err(e) => {
+                if request.forced_kind == Some(candidate.kind) {
+                    return Err(anyhow!(
+                        "Forced execution provider '{}' failed health check: {}",
+                        candidate.kind.env_name(),
+                        e
+                    )
+                    .into());
+                }
+
+                if debug_enabled {
+                    eprintln!(
+                        "⚠️  EP rejected for {} (attempt #{}): {}",
+                        ep_name,
+                        idx + 1,
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    if debug_enabled {
+        eprintln!(
+            "⚠️  All EPs failed or were rejected; falling back to CPU ({} threads)",
+            num_threads
+        );
+    }
+
+    let session = build_cpu_session(model_path, num_threads)?;
+
+    if debug_enabled {
+        eprintln!("✅ Execution provider selected: CPU");
+    }
+
+    Ok(session)
+}
+
+fn is_debug_enabled() -> bool {
+    std::env::var("DEBUG_STEMS").is_ok()
+}
+
+fn parse_ep_kind(value: &str) -> Option<EpKind> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "cpu" => Some(EpKind::Cpu),
+        "cuda" => Some(EpKind::Cuda),
+        "coreml" => Some(EpKind::CoreML),
+        "directml" => Some(EpKind::DirectML),
+        "onednn" | "one-dnn" | "one_dnn" | "dnnl" => Some(EpKind::OneDNN),
+        _ => None,
+    }
+}
+
+fn parse_disabled_ep_list(raw: Option<&str>) -> Result<Vec<EpKind>> {
+    let mut disabled = Vec::new();
+
+    let Some(raw) = raw else {
+        return Ok(disabled);
+    };
+
+    for token in raw.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        let kind = parse_ep_kind(token).ok_or_else(|| {
+            anyhow!(
+                "Unknown execution provider '{}' in STEMMER_EP_DISABLE (valid: cuda, coreml, directml, onednn)",
+                token
+            )
+        })?;
+
+        if kind == EpKind::Cpu {
+            return Err(anyhow!("'cpu' is not valid in STEMMER_EP_DISABLE").into());
+        }
+
+        if !disabled.contains(&kind) {
+            disabled.push(kind);
+        }
+    }
+
+    Ok(disabled)
+}
+
+fn default_ep_order_for_os(os: &str) -> Vec<EpKind> {
+    match os {
+        "windows" => vec![EpKind::Cuda, EpKind::DirectML, EpKind::OneDNN],
+        "macos" => vec![EpKind::CoreML, EpKind::OneDNN],
+        "linux" => vec![EpKind::Cuda, EpKind::OneDNN],
+        _ => vec![EpKind::OneDNN],
+    }
+}
+
+fn resolve_ep_request_for_os(
+    os: &str,
+    force_cpu: bool,
+    forced_ep: Option<&str>,
+    disabled_raw: Option<&str>,
+) -> Result<EpRequest> {
+    let disabled = parse_disabled_ep_list(disabled_raw)?;
+
+    if force_cpu {
+        return Ok(EpRequest {
+            kinds: Vec::new(),
+            forced_kind: None,
+            force_cpu: true,
+        });
+    }
+
+    if let Some(raw_forced) = forced_ep.map(str::trim).filter(|s| !s.is_empty()) {
+        let forced_kind = parse_ep_kind(raw_forced).ok_or_else(|| {
+            anyhow!(
+                "Unknown execution provider '{}' in STEMMER_EP_FORCE (valid: cpu, cuda, coreml, directml, onednn)",
+                raw_forced
+            )
+        })?;
+
+        if forced_kind == EpKind::Cpu {
+            return Ok(EpRequest {
+                kinds: Vec::new(),
+                forced_kind: None,
+                force_cpu: true,
+            });
+        }
+
+        if disabled.contains(&forced_kind) {
+            return Err(anyhow!(
+                "STEMMER_EP_FORCE={} conflicts with STEMMER_EP_DISABLE",
+                forced_kind.env_name()
+            )
+            .into());
+        }
+
+        return Ok(EpRequest {
+            kinds: vec![forced_kind],
+            forced_kind: Some(forced_kind),
+            force_cpu: false,
+        });
+    }
+
+    let mut kinds = default_ep_order_for_os(os);
+    kinds.retain(|kind| !disabled.contains(kind));
+
+    Ok(EpRequest {
+        kinds,
+        forced_kind: None,
+        force_cpu: false,
+    })
+}
+
+fn resolve_ep_request_from_env() -> Result<EpRequest> {
+    let force_cpu = std::env::var_os("STEMMER_FORCE_CPU").is_some();
+    let forced_ep = std::env::var("STEMMER_EP_FORCE").ok();
+    let disabled_raw = std::env::var("STEMMER_EP_DISABLE").ok();
+
+    resolve_ep_request_for_os(
+        std::env::consts::OS,
+        force_cpu,
+        forced_ep.as_deref(),
+        disabled_raw.as_deref(),
+    )
+}
+
+fn check_provider_is_usable<E: ExecutionProvider>(provider: &E) -> std::result::Result<(), String> {
+    if !provider.supported_by_platform() {
+        return Err("unsupported on this platform".to_string());
+    }
+
+    match provider.is_available() {
+        Ok(true) => Ok(()),
+        Ok(false) => Err("not available in this ONNX Runtime build".to_string()),
+        Err(e) => Err(format!("availability check failed: {e}")),
+    }
+}
+
+fn try_build_execution_provider(
+    kind: EpKind,
+) -> std::result::Result<ExecutionProviderDispatch, String> {
+    match kind {
+        EpKind::Cpu => Err("CPU does not require an execution provider registration".to_string()),
+        EpKind::Cuda => {
+            #[cfg(all(feature = "cuda", any(target_os = "linux", target_os = "windows")))]
+            {
+                let ep = CUDAExecutionProvider::default();
+                check_provider_is_usable(&ep)?;
+                return Ok(ep.build());
+            }
+            #[cfg(all(feature = "cuda", not(any(target_os = "linux", target_os = "windows"))))]
+            {
+                return Err("CUDA is only supported on Linux and Windows targets".to_string());
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                return Err("Cargo feature `cuda` is not enabled".to_string());
+            }
+        }
+        EpKind::CoreML => {
+            #[cfg(all(feature = "coreml", target_os = "macos"))]
+            {
+                let ep = CoreMLExecutionProvider::default();
+                check_provider_is_usable(&ep)?;
+                return Ok(ep.build());
+            }
+            #[cfg(all(feature = "coreml", not(target_os = "macos")))]
+            {
+                return Err("CoreML is only supported on macOS targets".to_string());
+            }
+            #[cfg(not(feature = "coreml"))]
+            {
+                return Err("Cargo feature `coreml` is not enabled".to_string());
+            }
+        }
+        EpKind::DirectML => {
+            #[cfg(all(feature = "directml", target_os = "windows"))]
+            {
+                let ep = DirectMLExecutionProvider::default();
+                check_provider_is_usable(&ep)?;
+                return Ok(ep.build());
+            }
+            #[cfg(all(feature = "directml", not(target_os = "windows")))]
+            {
+                return Err("DirectML is only supported on Windows targets".to_string());
+            }
+            #[cfg(not(feature = "directml"))]
+            {
+                return Err("Cargo feature `directml` is not enabled".to_string());
+            }
+        }
+        EpKind::OneDNN => {
+            #[cfg(feature = "onednn")]
+            {
+                let ep = OneDNNExecutionProvider::default();
+                check_provider_is_usable(&ep)?;
+                return Ok(ep.build());
+            }
+            #[cfg(not(feature = "onednn"))]
+            {
+                return Err("Cargo feature `onednn` is not enabled".to_string());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_ep_order_is_platform_specific() {
+        assert_eq!(
+            default_ep_order_for_os("windows"),
+            vec![EpKind::Cuda, EpKind::DirectML, EpKind::OneDNN]
+        );
+        assert_eq!(
+            default_ep_order_for_os("macos"),
+            vec![EpKind::CoreML, EpKind::OneDNN]
+        );
+        assert_eq!(
+            default_ep_order_for_os("linux"),
+            vec![EpKind::Cuda, EpKind::OneDNN]
+        );
+    }
+
+    #[test]
+    fn force_cpu_overrides_other_flags() {
+        let req = resolve_ep_request_for_os("linux", true, Some("cuda"), Some("onednn")).unwrap();
+        assert!(req.force_cpu);
+        assert!(req.kinds.is_empty());
+        assert_eq!(req.forced_kind, None);
+    }
+
+    #[test]
+    fn force_specific_provider() {
+        let req = resolve_ep_request_for_os("linux", false, Some("CUDA"), None).unwrap();
+        assert!(!req.force_cpu);
+        assert_eq!(req.kinds, vec![EpKind::Cuda]);
+        assert_eq!(req.forced_kind, Some(EpKind::Cuda));
+    }
+
+    #[test]
+    fn disable_list_filters_auto_order() {
+        let req =
+            resolve_ep_request_for_os("windows", false, None, Some("directml, onednn")).unwrap();
+        assert_eq!(req.kinds, vec![EpKind::Cuda]);
+        assert_eq!(req.forced_kind, None);
+    }
+
+    #[test]
+    fn force_and_disable_conflict_errors() {
+        let err = resolve_ep_request_for_os("windows", false, Some("directml"), Some("directml"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("STEMMER_EP_FORCE=directml conflicts with STEMMER_EP_DISABLE"));
+    }
+
+    #[test]
+    fn invalid_values_error() {
+        let err_force = resolve_ep_request_for_os("linux", false, Some("invalid"), None)
+            .unwrap_err()
+            .to_string();
+        assert!(err_force.contains("Unknown execution provider 'invalid' in STEMMER_EP_FORCE"));
+
+        let err_disable = resolve_ep_request_for_os("linux", false, None, Some("gpu"))
+            .unwrap_err()
+            .to_string();
+        assert!(err_disable.contains("Unknown execution provider 'gpu' in STEMMER_EP_DISABLE"));
+    }
+}

--- a/src/core/ep.rs
+++ b/src/core/ep.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(feature = "engine-mock", allow(dead_code))]
 
-use crate::error::Result;
+use crate::{error::Result, io::ep_cache};
 
 use anyhow::anyhow;
 use ort::{
@@ -32,7 +32,7 @@ pub(crate) enum EpKind {
 }
 
 impl EpKind {
-    fn label(self) -> &'static str {
+    pub(crate) fn label(self) -> &'static str {
         match self {
             EpKind::Cpu => "CPU",
             EpKind::Cuda => "CUDA",
@@ -42,7 +42,7 @@ impl EpKind {
         }
     }
 
-    fn env_name(self) -> &'static str {
+    pub(crate) fn env_name(self) -> &'static str {
         match self {
             EpKind::Cpu => "cpu",
             EpKind::Cuda => "cuda",
@@ -72,19 +72,26 @@ impl EpCandidate {
     }
 }
 
+pub(crate) struct SelectedSession {
+    pub(crate) session: Session,
+    pub(crate) kind: EpKind,
+}
+
 pub(crate) fn create_best_session<FCpu, FEp, FProbe>(
     model_path: &Path,
     num_threads: usize,
     mut build_cpu_session: FCpu,
     mut build_ep_session: FEp,
     mut probe_session: FProbe,
-) -> Result<Session>
+) -> Result<SelectedSession>
 where
     FCpu: FnMut(&Path, usize) -> Result<Session>,
     FEp: FnMut(&Path, usize, EpKind, ExecutionProviderDispatch) -> Result<Session>,
     FProbe: FnMut(&mut Session) -> Result<()>,
 {
     let debug_enabled = is_debug_enabled();
+    ep_cache::maybe_reset_from_env()?;
+    let cache_bypass = ep_cache::cache_bypass_enabled();
     let request = resolve_ep_request_from_env()?;
 
     if request.force_cpu {
@@ -96,7 +103,10 @@ where
         if debug_enabled {
             eprintln!("✅ Execution provider selected: CPU");
         }
-        return build_cpu_session(model_path, num_threads);
+        return Ok(SelectedSession {
+            session: build_cpu_session(model_path, num_threads)?,
+            kind: EpKind::Cpu,
+        });
     }
 
     if let Some(kind) = request.forced_kind {
@@ -107,6 +117,23 @@ where
 
     let mut providers: Vec<EpCandidate> = Vec::new();
     for kind in request.kinds {
+        let cached_reason = ep_cache::is_unhealthy(kind.env_name(), model_path)?;
+        if should_skip_due_to_cache(
+            kind,
+            request.forced_kind,
+            cache_bypass,
+            cached_reason.as_deref(),
+        ) {
+            if debug_enabled {
+                eprintln!(
+                    "ℹ️  Skipping {} from EP health cache: {} (set STEMMER_EP_CACHE_BYPASS=1 to retry)",
+                    kind.label(),
+                    cached_reason.unwrap_or_default()
+                );
+            }
+            continue;
+        }
+
         match try_build_execution_provider(kind) {
             Ok(dispatch) => providers.push(EpCandidate { kind, dispatch }),
             Err(reason) => {
@@ -173,7 +200,10 @@ where
                         idx + 1
                     );
                 }
-                return Ok(session);
+                return Ok(SelectedSession {
+                    session,
+                    kind: candidate.kind,
+                });
             }
             Err(e) => {
                 if request.forced_kind == Some(candidate.kind) {
@@ -210,11 +240,23 @@ where
         eprintln!("✅ Execution provider selected: CPU");
     }
 
-    Ok(session)
+    Ok(SelectedSession {
+        session,
+        kind: EpKind::Cpu,
+    })
 }
 
 fn is_debug_enabled() -> bool {
     std::env::var("DEBUG_STEMS").is_ok()
+}
+
+fn should_skip_due_to_cache(
+    kind: EpKind,
+    forced_kind: Option<EpKind>,
+    cache_bypass: bool,
+    cached_reason: Option<&str>,
+) -> bool {
+    forced_kind != Some(kind) && !cache_bypass && cached_reason.is_some()
 }
 
 fn parse_ep_kind(value: &str) -> Option<EpKind> {
@@ -503,5 +545,28 @@ mod tests {
     fn disable_cpu_is_rejected() {
         let err = parse_disabled_ep_list(Some("cpu")).unwrap_err().to_string();
         assert!(err.contains("'cpu' is not valid in STEMMER_EP_DISABLE"));
+    }
+
+    #[test]
+    fn cache_skip_rules_respect_force_and_bypass() {
+        assert!(should_skip_due_to_cache(
+            EpKind::CoreML,
+            None,
+            false,
+            Some("near-silent runtime output")
+        ));
+        assert!(!should_skip_due_to_cache(
+            EpKind::CoreML,
+            Some(EpKind::CoreML),
+            false,
+            Some("near-silent runtime output")
+        ));
+        assert!(!should_skip_due_to_cache(
+            EpKind::CoreML,
+            None,
+            true,
+            Some("near-silent runtime output")
+        ));
+        assert!(!should_skip_due_to_cache(EpKind::CoreML, None, false, None));
     }
 }

--- a/src/core/ep.rs
+++ b/src/core/ep.rs
@@ -478,4 +478,30 @@ mod tests {
             .to_string();
         assert!(err_disable.contains("Unknown execution provider 'gpu' in STEMMER_EP_DISABLE"));
     }
+
+    #[test]
+    fn force_value_is_case_and_whitespace_insensitive() {
+        let req = resolve_ep_request_for_os("macos", false, Some("  CoReMl  "), None).unwrap();
+        assert_eq!(req.forced_kind, Some(EpKind::CoreML));
+        assert_eq!(req.kinds, vec![EpKind::CoreML]);
+    }
+
+    #[test]
+    fn disable_list_deduplicates_and_handles_aliases() {
+        let disabled = parse_disabled_ep_list(Some(" one_dnn, onednn, one-dnn , dnnl ")).unwrap();
+        assert_eq!(disabled, vec![EpKind::OneDNN]);
+    }
+
+    #[test]
+    fn empty_force_uses_default_order() {
+        let req = resolve_ep_request_for_os("linux", false, Some("   "), None).unwrap();
+        assert_eq!(req.kinds, vec![EpKind::Cuda, EpKind::OneDNN]);
+        assert_eq!(req.forced_kind, None);
+    }
+
+    #[test]
+    fn disable_cpu_is_rejected() {
+        let err = parse_disabled_ep_list(Some("cpu")).unwrap_err().to_string();
+        assert!(err.contains("'cpu' is not valid in STEMMER_EP_DISABLE"));
+    }
 }

--- a/src/core/ep.rs
+++ b/src/core/ep.rs
@@ -1,18 +1,26 @@
 #![cfg_attr(feature = "engine-mock", allow(dead_code))]
 
-use crate::{error::Result, io::ep_cache};
+use crate::{
+    error::Result,
+    io::{ep_cache, paths},
+};
 
 use anyhow::anyhow;
 use ort::{
     execution_providers::{ExecutionProvider, ExecutionProviderDispatch},
     session::Session,
 };
-use std::path::Path;
+use std::{num::NonZeroUsize, path::Path};
 
 // CUDA: Linux and Windows only
 #[cfg(all(feature = "cuda", any(target_os = "linux", target_os = "windows")))]
 use ort::execution_providers::CUDAExecutionProvider;
 // CoreML: macOS only (Apple Silicon)
+#[cfg(all(feature = "coreml", target_os = "macos"))]
+use ort::execution_providers::coreml::{
+    ComputeUnits as CoreMLComputeUnits, ModelFormat as CoreMLModelFormat,
+    SpecializationStrategy as CoreMLSpecializationStrategy,
+};
 #[cfg(all(feature = "coreml", target_os = "macos"))]
 use ort::execution_providers::CoreMLExecutionProvider;
 // DirectML: Windows only
@@ -21,6 +29,9 @@ use ort::execution_providers::DirectMLExecutionProvider;
 // oneDNN: x86 Linux/Windows only
 #[cfg(feature = "onednn")]
 use ort::execution_providers::OneDNNExecutionProvider;
+// XNNPACK: ARM/x86 CPU acceleration
+#[cfg(feature = "xnnpack")]
+use ort::execution_providers::XNNPACKExecutionProvider;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum EpKind {
@@ -29,6 +40,7 @@ pub(crate) enum EpKind {
     CoreML,
     DirectML,
     OneDNN,
+    Xnnpack,
 }
 
 impl EpKind {
@@ -39,6 +51,7 @@ impl EpKind {
             EpKind::CoreML => "CoreML",
             EpKind::DirectML => "DirectML",
             EpKind::OneDNN => "oneDNN",
+            EpKind::Xnnpack => "XNNPACK",
         }
     }
 
@@ -49,6 +62,7 @@ impl EpKind {
             EpKind::CoreML => "coreml",
             EpKind::DirectML => "directml",
             EpKind::OneDNN => "onednn",
+            EpKind::Xnnpack => "xnnpack",
         }
     }
 }
@@ -191,8 +205,35 @@ where
                 }
             };
 
+        let recently_healthy =
+            ep_cache::is_recently_healthy(candidate.kind.env_name(), model_path)?;
+        if recently_healthy {
+            if debug_enabled {
+                eprintln!(
+                    "✅ Execution provider selected: {} (attempt #{}, cached healthy probe)",
+                    ep_name,
+                    idx + 1
+                );
+            }
+            return Ok(SelectedSession {
+                session,
+                kind: candidate.kind,
+            });
+        }
+
         match probe_session(&mut session) {
             Ok(()) => {
+                if let Err(cache_err) =
+                    ep_cache::mark_healthy(candidate.kind.env_name(), model_path)
+                {
+                    if debug_enabled {
+                        eprintln!(
+                            "⚠️  Failed to persist healthy EP probe entry for {}: {}",
+                            ep_name, cache_err
+                        );
+                    }
+                }
+
                 if debug_enabled {
                     eprintln!(
                         "✅ Execution provider selected: {} (attempt #{})",
@@ -213,6 +254,22 @@ where
                         e
                     )
                     .into());
+                }
+
+                if let Err(cache_err) =
+                    ep_cache::mark_unhealthy(candidate.kind.env_name(), model_path, &e.to_string())
+                {
+                    if debug_enabled {
+                        eprintln!(
+                            "⚠️  Failed to persist unhealthy EP cache entry for {}: {}",
+                            ep_name, cache_err
+                        );
+                    }
+                } else if debug_enabled {
+                    eprintln!(
+                        "ℹ️  Marked {} as unhealthy for this model (cached for 7 days)",
+                        ep_name
+                    );
                 }
 
                 if debug_enabled {
@@ -250,6 +307,87 @@ fn is_debug_enabled() -> bool {
     std::env::var("DEBUG_STEMS").is_ok()
 }
 
+fn parse_env_usize(name: &str) -> Option<usize> {
+    let raw = std::env::var(name).ok()?;
+    let parsed = raw.parse::<usize>().ok()?;
+    (parsed > 0).then_some(parsed)
+}
+
+fn parse_env_bool(name: &str) -> Option<bool> {
+    let raw = std::env::var(name).ok()?;
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+#[cfg(all(feature = "coreml", target_os = "macos"))]
+fn coreml_compute_units() -> CoreMLComputeUnits {
+    match std::env::var("STEMMER_COREML_UNITS")
+        .ok()
+        .as_deref()
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("all") => CoreMLComputeUnits::All,
+        Some("ane") | Some("cpuandneuralengine") | Some("cpu_and_neural_engine") => {
+            CoreMLComputeUnits::CPUAndNeuralEngine
+        }
+        Some("gpu") | Some("cpuandgpu") | Some("cpu_and_gpu") => CoreMLComputeUnits::CPUAndGPU,
+        Some("cpu") | Some("cpuonly") | Some("cpu_only") => CoreMLComputeUnits::CPUOnly,
+        _ => CoreMLComputeUnits::CPUAndGPU,
+    }
+}
+
+#[cfg(all(feature = "coreml", target_os = "macos"))]
+fn coreml_model_format() -> CoreMLModelFormat {
+    match std::env::var("STEMMER_COREML_MODEL_FORMAT")
+        .ok()
+        .as_deref()
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("neuralnetwork") | Some("neural_network") | Some("nn") => {
+            CoreMLModelFormat::NeuralNetwork
+        }
+        _ => CoreMLModelFormat::MLProgram,
+    }
+}
+
+#[cfg(all(feature = "coreml", target_os = "macos"))]
+fn coreml_specialization_strategy() -> CoreMLSpecializationStrategy {
+    match std::env::var("STEMMER_COREML_SPECIALIZATION")
+        .ok()
+        .as_deref()
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("fastprediction") | Some("fast_prediction") | Some("fast") => {
+            CoreMLSpecializationStrategy::FastPrediction
+        }
+        _ => CoreMLSpecializationStrategy::Default,
+    }
+}
+
+#[cfg(all(feature = "coreml", target_os = "macos"))]
+fn coreml_static_input_shapes() -> bool {
+    parse_env_bool("STEMMER_COREML_STATIC_INPUTS").unwrap_or(true)
+}
+
+fn xnnpack_threads() -> NonZeroUsize {
+    let configured = parse_env_usize("STEMMER_ORT_INTRA_THREADS").or_else(|| {
+        std::thread::available_parallelism()
+            .ok()
+            .map(|threads| threads.get())
+    });
+
+    NonZeroUsize::new(configured.unwrap_or(4)).expect("XNNPACK thread count must be non-zero")
+}
+
 fn should_skip_due_to_cache(
     kind: EpKind,
     forced_kind: Option<EpKind>,
@@ -266,6 +404,7 @@ fn parse_ep_kind(value: &str) -> Option<EpKind> {
         "coreml" => Some(EpKind::CoreML),
         "directml" => Some(EpKind::DirectML),
         "onednn" | "one-dnn" | "one_dnn" | "dnnl" => Some(EpKind::OneDNN),
+        "xnnpack" | "xnn" => Some(EpKind::Xnnpack),
         _ => None,
     }
 }
@@ -280,7 +419,7 @@ fn parse_disabled_ep_list(raw: Option<&str>) -> Result<Vec<EpKind>> {
     for token in raw.split(',').map(str::trim).filter(|s| !s.is_empty()) {
         let kind = parse_ep_kind(token).ok_or_else(|| {
             anyhow!(
-                "Unknown execution provider '{}' in STEMMER_EP_DISABLE (valid: cuda, coreml, directml, onednn)",
+                "Unknown execution provider '{}' in STEMMER_EP_DISABLE (valid: cuda, coreml, directml, onednn, xnnpack)",
                 token
             )
         })?;
@@ -297,17 +436,25 @@ fn parse_disabled_ep_list(raw: Option<&str>) -> Result<Vec<EpKind>> {
     Ok(disabled)
 }
 
-fn default_ep_order_for_os(os: &str) -> Vec<EpKind> {
-    match os {
-        "windows" => vec![EpKind::Cuda, EpKind::DirectML, EpKind::OneDNN],
-        "macos" => vec![EpKind::CoreML, EpKind::OneDNN],
-        "linux" => vec![EpKind::Cuda, EpKind::OneDNN],
-        _ => vec![EpKind::OneDNN],
+fn default_ep_order_for_target(os: &str, arch: &str) -> Vec<EpKind> {
+    match (os, arch) {
+        ("windows", _) => vec![
+            EpKind::Cuda,
+            EpKind::DirectML,
+            EpKind::OneDNN,
+            EpKind::Xnnpack,
+        ],
+        ("macos", "aarch64") => vec![EpKind::CoreML, EpKind::Xnnpack],
+        ("macos", _) => vec![EpKind::Xnnpack],
+        ("linux", "aarch64") => vec![EpKind::Cuda, EpKind::Xnnpack],
+        ("linux", _) => vec![EpKind::Cuda, EpKind::OneDNN, EpKind::Xnnpack],
+        _ => vec![EpKind::Xnnpack, EpKind::OneDNN],
     }
 }
 
-fn resolve_ep_request_for_os(
+fn resolve_ep_request_for_target(
     os: &str,
+    arch: &str,
     force_cpu: bool,
     forced_ep: Option<&str>,
     disabled_raw: Option<&str>,
@@ -325,7 +472,7 @@ fn resolve_ep_request_for_os(
     if let Some(raw_forced) = forced_ep.map(str::trim).filter(|s| !s.is_empty()) {
         let forced_kind = parse_ep_kind(raw_forced).ok_or_else(|| {
             anyhow!(
-                "Unknown execution provider '{}' in STEMMER_EP_FORCE (valid: cpu, cuda, coreml, directml, onednn)",
+                "Unknown execution provider '{}' in STEMMER_EP_FORCE (valid: cpu, cuda, coreml, directml, onednn, xnnpack)",
                 raw_forced
             )
         })?;
@@ -353,7 +500,7 @@ fn resolve_ep_request_for_os(
         });
     }
 
-    let mut kinds = default_ep_order_for_os(os);
+    let mut kinds = default_ep_order_for_target(os, arch);
     kinds.retain(|kind| !disabled.contains(kind));
 
     Ok(EpRequest {
@@ -368,8 +515,9 @@ fn resolve_ep_request_from_env() -> Result<EpRequest> {
     let forced_ep = std::env::var("STEMMER_EP_FORCE").ok();
     let disabled_raw = std::env::var("STEMMER_EP_DISABLE").ok();
 
-    resolve_ep_request_for_os(
+    resolve_ep_request_for_target(
         std::env::consts::OS,
+        std::env::consts::ARCH,
         force_cpu,
         forced_ep.as_deref(),
         disabled_raw.as_deref(),
@@ -412,7 +560,20 @@ fn try_build_execution_provider(
         EpKind::CoreML => {
             #[cfg(all(feature = "coreml", target_os = "macos"))]
             {
-                let ep = CoreMLExecutionProvider::default();
+                let mut ep = CoreMLExecutionProvider::default()
+                    .with_model_format(coreml_model_format())
+                    .with_compute_units(coreml_compute_units())
+                    .with_static_input_shapes(coreml_static_input_shapes())
+                    .with_specialization_strategy(coreml_specialization_strategy());
+
+                if let Ok(cache_dir) = paths::coreml_cache_dir() {
+                    ep = ep.with_model_cache_dir(cache_dir.to_string_lossy().into_owned());
+                }
+
+                if is_debug_enabled() {
+                    ep = ep.with_profile_compute_plan(true);
+                }
+
                 check_provider_is_usable(&ep)?;
                 return Ok(ep.build());
             }
@@ -453,6 +614,19 @@ fn try_build_execution_provider(
                 return Err("Cargo feature `onednn` is not enabled".to_string());
             }
         }
+        EpKind::Xnnpack => {
+            #[cfg(feature = "xnnpack")]
+            {
+                let ep = XNNPACKExecutionProvider::default()
+                    .with_intra_op_num_threads(xnnpack_threads());
+                check_provider_is_usable(&ep)?;
+                return Ok(ep.build());
+            }
+            #[cfg(not(feature = "xnnpack"))]
+            {
+                return Err("Cargo feature `xnnpack` is not enabled".to_string());
+            }
+        }
     }
 }
 
@@ -463,22 +637,37 @@ mod tests {
     #[test]
     fn default_ep_order_is_platform_specific() {
         assert_eq!(
-            default_ep_order_for_os("windows"),
-            vec![EpKind::Cuda, EpKind::DirectML, EpKind::OneDNN]
+            default_ep_order_for_target("windows", "x86_64"),
+            vec![
+                EpKind::Cuda,
+                EpKind::DirectML,
+                EpKind::OneDNN,
+                EpKind::Xnnpack
+            ]
         );
         assert_eq!(
-            default_ep_order_for_os("macos"),
-            vec![EpKind::CoreML, EpKind::OneDNN]
+            default_ep_order_for_target("macos", "aarch64"),
+            vec![EpKind::CoreML, EpKind::Xnnpack]
         );
         assert_eq!(
-            default_ep_order_for_os("linux"),
-            vec![EpKind::Cuda, EpKind::OneDNN]
+            default_ep_order_for_target("macos", "x86_64"),
+            vec![EpKind::Xnnpack]
+        );
+        assert_eq!(
+            default_ep_order_for_target("linux", "x86_64"),
+            vec![EpKind::Cuda, EpKind::OneDNN, EpKind::Xnnpack]
+        );
+        assert_eq!(
+            default_ep_order_for_target("linux", "aarch64"),
+            vec![EpKind::Cuda, EpKind::Xnnpack]
         );
     }
 
     #[test]
     fn force_cpu_overrides_other_flags() {
-        let req = resolve_ep_request_for_os("linux", true, Some("cuda"), Some("onednn")).unwrap();
+        let req =
+            resolve_ep_request_for_target("linux", "x86_64", true, Some("cuda"), Some("onednn"))
+                .unwrap();
         assert!(req.force_cpu);
         assert!(req.kinds.is_empty());
         assert_eq!(req.forced_kind, None);
@@ -486,7 +675,8 @@ mod tests {
 
     #[test]
     fn force_specific_provider() {
-        let req = resolve_ep_request_for_os("linux", false, Some("CUDA"), None).unwrap();
+        let req =
+            resolve_ep_request_for_target("linux", "x86_64", false, Some("CUDA"), None).unwrap();
         assert!(!req.force_cpu);
         assert_eq!(req.kinds, vec![EpKind::Cuda]);
         assert_eq!(req.forced_kind, Some(EpKind::Cuda));
@@ -494,36 +684,52 @@ mod tests {
 
     #[test]
     fn disable_list_filters_auto_order() {
-        let req =
-            resolve_ep_request_for_os("windows", false, None, Some("directml, onednn")).unwrap();
-        assert_eq!(req.kinds, vec![EpKind::Cuda]);
+        let req = resolve_ep_request_for_target(
+            "windows",
+            "x86_64",
+            false,
+            None,
+            Some("directml, onednn"),
+        )
+        .unwrap();
+        assert_eq!(req.kinds, vec![EpKind::Cuda, EpKind::Xnnpack]);
         assert_eq!(req.forced_kind, None);
     }
 
     #[test]
     fn force_and_disable_conflict_errors() {
-        let err = resolve_ep_request_for_os("windows", false, Some("directml"), Some("directml"))
-            .unwrap_err()
-            .to_string();
+        let err = resolve_ep_request_for_target(
+            "windows",
+            "x86_64",
+            false,
+            Some("directml"),
+            Some("directml"),
+        )
+        .unwrap_err()
+        .to_string();
         assert!(err.contains("STEMMER_EP_FORCE=directml conflicts with STEMMER_EP_DISABLE"));
     }
 
     #[test]
     fn invalid_values_error() {
-        let err_force = resolve_ep_request_for_os("linux", false, Some("invalid"), None)
-            .unwrap_err()
-            .to_string();
+        let err_force =
+            resolve_ep_request_for_target("linux", "x86_64", false, Some("invalid"), None)
+                .unwrap_err()
+                .to_string();
         assert!(err_force.contains("Unknown execution provider 'invalid' in STEMMER_EP_FORCE"));
 
-        let err_disable = resolve_ep_request_for_os("linux", false, None, Some("gpu"))
-            .unwrap_err()
-            .to_string();
+        let err_disable =
+            resolve_ep_request_for_target("linux", "x86_64", false, None, Some("gpu"))
+                .unwrap_err()
+                .to_string();
         assert!(err_disable.contains("Unknown execution provider 'gpu' in STEMMER_EP_DISABLE"));
     }
 
     #[test]
     fn force_value_is_case_and_whitespace_insensitive() {
-        let req = resolve_ep_request_for_os("macos", false, Some("  CoReMl  "), None).unwrap();
+        let req =
+            resolve_ep_request_for_target("macos", "aarch64", false, Some("  CoReMl  "), None)
+                .unwrap();
         assert_eq!(req.forced_kind, Some(EpKind::CoreML));
         assert_eq!(req.kinds, vec![EpKind::CoreML]);
     }
@@ -535,9 +741,19 @@ mod tests {
     }
 
     #[test]
+    fn xnnpack_aliases_are_supported() {
+        let disabled = parse_disabled_ep_list(Some("xnn, xnnpack")).unwrap();
+        assert_eq!(disabled, vec![EpKind::Xnnpack]);
+    }
+
+    #[test]
     fn empty_force_uses_default_order() {
-        let req = resolve_ep_request_for_os("linux", false, Some("   "), None).unwrap();
-        assert_eq!(req.kinds, vec![EpKind::Cuda, EpKind::OneDNN]);
+        let req =
+            resolve_ep_request_for_target("linux", "x86_64", false, Some("   "), None).unwrap();
+        assert_eq!(
+            req.kinds,
+            vec![EpKind::Cuda, EpKind::OneDNN, EpKind::Xnnpack]
+        );
         assert_eq!(req.forced_kind, None);
     }
 

--- a/src/core/splitter.rs
+++ b/src/core/splitter.rs
@@ -47,7 +47,12 @@ pub fn split_file(input_path: &str, opts: SplitOptions) -> Result<SplitResult> {
     }
 
     if std::env::var("DEBUG_STEMS").is_ok() {
-        eprintln!("Window settings: win={}, hop={}, overlap={}", win, hop, win - hop);
+        eprintln!(
+            "Window settings: win={}, hop={}, overlap={}",
+            win,
+            hop,
+            win - hop
+        );
     }
 
     let stems_names = mf.stems.clone();
@@ -124,16 +129,22 @@ pub fn split_file(input_path: &str, opts: SplitOptions) -> Result<SplitResult> {
     fs::create_dir_all(&opts.output_dir)?;
 
     emit_split_progress(SplitProgress::Stage("write_stems"));
-    
+
     if std::env::var("DEBUG_STEMS").is_ok() {
         for st in 0..stems_count {
-            let max_val = acc[st].iter()
+            let max_val = acc[st]
+                .iter()
                 .map(|s| s[0].abs().max(s[1].abs()))
                 .fold(0.0f32, f32::max);
-            eprintln!("Accumulator [stem {}]: max_value={:.6}, samples={}", st, max_val, acc[st].len());
+            eprintln!(
+                "Accumulator [stem {}]: max_value={:.6}, samples={}",
+                st,
+                max_val,
+                acc[st].len()
+            );
         }
     }
-    
+
     let stem_to_wav = |st: usize, base: &str| -> Result<String> {
         let mut inter = Vec::with_capacity(n * 2);
 

--- a/src/core/splitter.rs
+++ b/src/core/splitter.rs
@@ -1,21 +1,119 @@
 use crate::{
     core::{
-        audio::{read_audio, write_audio},
-        dsp::to_planar_stereo,
+        audio::{create_wav_writer, read_audio, sample_to_i16, WavWriter},
         engine,
     },
     error::Result,
     io::progress::{emit_split_progress, SplitProgress},
     model::model_manager::ensure_model,
-    types::{AudioData, SplitOptions, SplitResult},
+    types::{SplitOptions, SplitResult},
 };
 
 use std::{
     collections::HashMap,
-    fs,
     path::{Path, PathBuf},
 };
-use tempfile::tempdir;
+
+struct StemOutput {
+    stem_idx: usize,
+    stem_name: String,
+    writer: WavWriter,
+}
+
+fn audio_frame_count(samples: &[f32], channels: u16) -> usize {
+    let channels = usize::from(channels.max(1));
+    samples.len() / channels
+}
+
+fn fill_stereo_window(
+    samples: &[f32],
+    channels: u16,
+    start_frame: usize,
+    left_raw: &mut [f32],
+    right_raw: &mut [f32],
+) {
+    let channels = usize::from(channels.max(1));
+
+    for i in 0..left_raw.len() {
+        let frame = start_frame + i;
+        let base = frame * channels;
+        if base >= samples.len() {
+            left_raw[i] = 0.0;
+            right_raw[i] = 0.0;
+            continue;
+        }
+
+        let left = samples[base];
+        let right = if channels == 1 {
+            left
+        } else {
+            samples.get(base + 1).copied().unwrap_or(left)
+        };
+
+        left_raw[i] = left;
+        right_raw[i] = right;
+    }
+}
+
+fn build_output_paths(input_path: &str, output_dir: &str) -> (String, String, String, String) {
+    let file_stem = Path::new(input_path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("output");
+    let base = PathBuf::from(output_dir).join(file_stem);
+
+    (
+        format!("{}_vocals.wav", base.to_string_lossy()),
+        format!("{}_drums.wav", base.to_string_lossy()),
+        format!("{}_bass.wav", base.to_string_lossy()),
+        format!("{}_other.wav", base.to_string_lossy()),
+    )
+}
+
+fn build_stem_outputs(
+    names: &[String],
+    stems_count: usize,
+    sample_rate: u32,
+    vocals_out: String,
+    drums_out: String,
+    bass_out: String,
+    other_out: String,
+) -> Result<Vec<StemOutput>> {
+    let mut name_idx: HashMap<String, usize> = HashMap::new();
+    for (i, name) in names.iter().enumerate() {
+        name_idx.insert(name.to_lowercase(), i);
+    }
+
+    let get_idx = |key: &str, fallback: usize| -> usize {
+        name_idx
+            .get(key)
+            .copied()
+            .unwrap_or(fallback.min(stems_count.saturating_sub(1)))
+    };
+
+    Ok(vec![
+        StemOutput {
+            stem_idx: get_idx("vocals", 0),
+            stem_name: "vocals".to_string(),
+            writer: create_wav_writer(&vocals_out, sample_rate, 2)?,
+        },
+        StemOutput {
+            stem_idx: get_idx("drums", 1),
+            stem_name: "drums".to_string(),
+            writer: create_wav_writer(&drums_out, sample_rate, 2)?,
+        },
+        StemOutput {
+            stem_idx: get_idx("bass", 2),
+            stem_name: "bass".to_string(),
+            writer: create_wav_writer(&bass_out, sample_rate, 2)?,
+        },
+        StemOutput {
+            stem_idx: get_idx("other", 3),
+            stem_name: "other".to_string(),
+            writer: create_wav_writer(&other_out, sample_rate, 2)?,
+        },
+    ])
+}
 
 pub fn split_file(input_path: &str, opts: SplitOptions) -> Result<SplitResult> {
     emit_split_progress(SplitProgress::Stage("resolve_model"));
@@ -32,8 +130,7 @@ pub fn split_file(input_path: &str, opts: SplitOptions) -> Result<SplitResult> {
 
     emit_split_progress(SplitProgress::Stage("read_audio"));
     let audio = read_audio(input_path)?;
-    let stereo = to_planar_stereo(&audio.samples, audio.channels);
-    let n = stereo.len();
+    let n = audio_frame_count(&audio.samples, audio.channels);
 
     if n == 0 {
         return Err(anyhow::anyhow!("Empty audio").into());
@@ -55,62 +152,7 @@ pub fn split_file(input_path: &str, opts: SplitOptions) -> Result<SplitResult> {
         );
     }
 
-    let stems_names = mf.stems.clone();
-    let mut stems_count = stems_names.len().max(1);
-
-    let tmp = tempdir()?;
-    let tmp_dir = tmp.path().to_path_buf();
-
-    let mut left_raw = vec![0f32; win];
-    let mut right_raw = vec![0f32; win];
-
-    // Accumulator for each stem - no windowing needed since model outputs are already processed
-    let mut acc: Vec<Vec<[f32; 2]>> = Vec::new();
-
-    let mut pos = 0usize;
-    let mut first_chunk = true;
-
-    emit_split_progress(SplitProgress::Stage("infer"));
-    while pos < n {
-        // Extract audio chunk
-        for i in 0..win {
-            let idx = pos + i;
-            if idx < n {
-                left_raw[i] = stereo[idx][0];
-                right_raw[i] = stereo[idx][1];
-            } else {
-                left_raw[i] = 0.0;
-                right_raw[i] = 0.0;
-            }
-        }
-
-        // Run inference - model already handles windowing internally
-        let out = engine::run_window_demucs(&left_raw, &right_raw)?;
-        let (s_count, _, t_out) = (out.shape()[0], out.shape()[1], out.shape()[2]);
-
-        if first_chunk {
-            stems_count = s_count;
-            acc = vec![vec![[0f32; 2]; n]; stems_count];
-            first_chunk = false;
-        }
-
-        // Copy only the non-overlapping part (first 'hop' samples of each window)
-        // This avoids overwriting data from previous windows
-        let copy_len = hop.min(t_out).min(n - pos);
-        for st in 0..stems_count {
-            for i in 0..copy_len {
-                acc[st][pos + i][0] = out[(st, 0, i)];
-                acc[st][pos + i][1] = out[(st, 1, i)];
-            }
-        }
-
-        if pos + hop >= n {
-            break;
-        }
-        pos += hop;
-    }
-
-    let names = if stems_names.is_empty() {
+    let names = if mf.stems.is_empty() {
         vec![
             "vocals".into(),
             "drums".into(),
@@ -118,85 +160,86 @@ pub fn split_file(input_path: &str, opts: SplitOptions) -> Result<SplitResult> {
             "other".into(),
         ]
     } else {
-        stems_names
+        mf.stems.clone()
     };
 
-    let mut name_idx: HashMap<String, usize> = HashMap::new();
-    for (i, name) in names.iter().enumerate() {
-        name_idx.insert(name.to_lowercase(), i);
-    }
+    let (vocals_out, drums_out, bass_out, other_out) =
+        build_output_paths(input_path, &opts.output_dir);
 
-    fs::create_dir_all(&opts.output_dir)?;
+    let mut left_raw = vec![0f32; win];
+    let mut right_raw = vec![0f32; win];
+    let mut stem_outputs: Vec<StemOutput> = Vec::new();
 
-    emit_split_progress(SplitProgress::Stage("write_stems"));
+    let mut pos = 0usize;
+    let mut chunk_done = 0usize;
+    let total_chunks = if n <= hop { 1 } else { (n - 1) / hop + 1 };
+    let mut first_chunk = true;
 
-    if std::env::var("DEBUG_STEMS").is_ok() {
-        for st in 0..stems_count {
-            let max_val = acc[st]
-                .iter()
-                .map(|s| s[0].abs().max(s[1].abs()))
-                .fold(0.0f32, f32::max);
-            eprintln!(
-                "Accumulator [stem {}]: max_value={:.6}, samples={}",
-                st,
-                max_val,
-                acc[st].len()
-            );
+    emit_split_progress(SplitProgress::Stage("infer"));
+    while pos < n {
+        fill_stereo_window(
+            &audio.samples,
+            audio.channels,
+            pos,
+            &mut left_raw,
+            &mut right_raw,
+        );
+
+        let out = engine::run_window_demucs(&left_raw, &right_raw)?;
+        let (stems_count, _, t_out) = (out.shape()[0], out.shape()[1], out.shape()[2]);
+
+        if first_chunk {
+            stem_outputs = build_stem_outputs(
+                &names,
+                stems_count,
+                mf.sample_rate,
+                vocals_out.clone(),
+                drums_out.clone(),
+                bass_out.clone(),
+                other_out.clone(),
+            )?;
+            first_chunk = false;
         }
-    }
 
-    let stem_to_wav = |st: usize, base: &str| -> Result<String> {
-        let mut inter = Vec::with_capacity(n * 2);
-
-        for sample in &acc[st][..n] {
-            inter.push(sample[0]);
-            inter.push(sample[1]);
+        let copy_len = hop.min(t_out).min(n - pos);
+        for stem_output in &mut stem_outputs {
+            for i in 0..copy_len {
+                stem_output
+                    .writer
+                    .write_sample(sample_to_i16(out[(stem_output.stem_idx, 0, i)]))
+                    .map_err(anyhow::Error::from)?;
+                stem_output
+                    .writer
+                    .write_sample(sample_to_i16(out[(stem_output.stem_idx, 1, i)]))
+                    .map_err(anyhow::Error::from)?;
+            }
         }
 
-        emit_split_progress(SplitProgress::Writing {
-            stem: base.to_string(),
-            done: n,
-            total: n,
-            percent: 100.0,
+        chunk_done += 1;
+        emit_split_progress(SplitProgress::Chunks {
+            done: chunk_done,
+            total: total_chunks,
+            percent: chunk_done as f32 / total_chunks as f32 * 100.0,
         });
 
-        let data = AudioData {
-            samples: inter,
-            sample_rate: mf.sample_rate,
-            channels: 2,
-        };
+        if pos + hop >= n {
+            break;
+        }
+        pos += hop;
+    }
 
-        let p = tmp_dir.join(format!("{base}.wav"));
-        write_audio(p.to_str().unwrap(), &data)?;
-
-        Ok(p.to_string_lossy().into())
-    };
-
-    let get_idx = |key: &str, fallback: usize| -> usize {
-        name_idx
-            .get(key)
-            .copied()
-            .unwrap_or(fallback.min(stems_count.saturating_sub(1)))
-    };
-
-    let v_path = stem_to_wav(get_idx("vocals", 0), "vocals")?;
-    let d_path = stem_to_wav(get_idx("drums", 1), "drums")?;
-    let b_path = stem_to_wav(get_idx("bass", 2), "bass")?;
-    let o_path = stem_to_wav(get_idx("other", 3), "other")?;
+    emit_split_progress(SplitProgress::Stage("write_stems"));
+    for (idx, stem_output) in stem_outputs.into_iter().enumerate() {
+        emit_split_progress(SplitProgress::Writing {
+            stem: stem_output.stem_name,
+            done: idx + 1,
+            total: 4,
+            percent: (idx + 1) as f32 / 4.0 * 100.0,
+        });
+        stem_output.writer.finalize().map_err(anyhow::Error::from)?;
+    }
 
     emit_split_progress(SplitProgress::Stage("finalize"));
-
-    let file_stem = Path::new(input_path)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("output");
-    let base = PathBuf::from(&opts.output_dir).join(file_stem);
-
-    let vocals_out = copy_to(&v_path, &format!("{}_vocals.wav", base.to_string_lossy()))?;
-    let drums_out = copy_to(&d_path, &format!("{}_drums.wav", base.to_string_lossy()))?;
-    let bass_out = copy_to(&b_path, &format!("{}_bass.wav", base.to_string_lossy()))?;
-    let other_out = copy_to(&o_path, &format!("{}_other.wav", base.to_string_lossy()))?;
-
     emit_split_progress(SplitProgress::Finished);
 
     Ok(SplitResult {
@@ -205,9 +248,4 @@ pub fn split_file(input_path: &str, opts: SplitOptions) -> Result<SplitResult> {
         bass_path: bass_out,
         other_path: other_out,
     })
-}
-
-fn copy_to(src: &str, dst: &str) -> Result<String> {
-    fs::copy(src, dst)?;
-    Ok(dst.to_string())
 }

--- a/src/io/ep_cache.rs
+++ b/src/io/ep_cache.rs
@@ -1,6 +1,9 @@
 #![cfg_attr(feature = "engine-mock", allow(dead_code))]
 
-use crate::{error::Result, io::paths::ep_cache_file};
+use crate::{
+    error::Result,
+    io::paths::{ep_cache_file, ep_probe_cache_file},
+};
 
 use serde::{Deserialize, Serialize};
 use std::{
@@ -11,6 +14,7 @@ use std::{
 
 const CACHE_SCHEMA_VERSION: u32 = 1;
 const UNHEALTHY_TTL_SECS: u64 = 7 * 24 * 60 * 60;
+const HEALTHY_TTL_SECS: u64 = 24 * 60 * 60;
 
 #[derive(Debug, Clone)]
 struct EpCacheKey {
@@ -39,7 +43,33 @@ struct EpHealthCacheFile {
     entries: Vec<EpHealthEntry>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EpSuccessEntry {
+    provider: String,
+    model_id: String,
+    os: String,
+    arch: String,
+    ort_api: u32,
+    updated_at_unix: u64,
+    success_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EpSuccessCacheFile {
+    version: u32,
+    entries: Vec<EpSuccessEntry>,
+}
+
 impl Default for EpHealthCacheFile {
+    fn default() -> Self {
+        Self {
+            version: CACHE_SCHEMA_VERSION,
+            entries: Vec::new(),
+        }
+    }
+}
+
+impl Default for EpSuccessCacheFile {
     fn default() -> Self {
         Self {
             version: CACHE_SCHEMA_VERSION,
@@ -54,7 +84,10 @@ pub(crate) fn cache_bypass_enabled() -> bool {
 
 pub(crate) fn maybe_reset_from_env() -> Result<()> {
     let cache_path = ep_cache_file()?;
-    maybe_reset_cache_file(&cache_path, env_flag_enabled("STEMMER_EP_CACHE_RESET"))
+    let probe_cache_path = ep_probe_cache_file()?;
+    let reset_enabled = env_flag_enabled("STEMMER_EP_CACHE_RESET");
+    maybe_reset_cache_file(&cache_path, reset_enabled)?;
+    maybe_reset_cache_file(&probe_cache_path, reset_enabled)
 }
 
 pub(crate) fn is_unhealthy(provider: &str, model_path: &Path) -> Result<Option<String>> {
@@ -66,7 +99,21 @@ pub(crate) fn is_unhealthy(provider: &str, model_path: &Path) -> Result<Option<S
 pub(crate) fn mark_unhealthy(provider: &str, model_path: &Path, reason: &str) -> Result<()> {
     let cache_path = ep_cache_file()?;
     let key = build_key(provider, model_path);
+    let probe_cache_path = ep_probe_cache_file()?;
+    clear_healthy_in_file(&probe_cache_path, &key)?;
     mark_unhealthy_in_file(&cache_path, &key, reason)
+}
+
+pub(crate) fn is_recently_healthy(provider: &str, model_path: &Path) -> Result<bool> {
+    let cache_path = ep_probe_cache_file()?;
+    let key = build_key(provider, model_path);
+    is_recently_healthy_in_file(&cache_path, &key, cache_bypass_enabled())
+}
+
+pub(crate) fn mark_healthy(provider: &str, model_path: &Path) -> Result<()> {
+    let cache_path = ep_probe_cache_file()?;
+    let key = build_key(provider, model_path);
+    mark_healthy_in_file(&cache_path, &key)
 }
 
 fn env_flag_enabled(name: &str) -> bool {
@@ -122,7 +169,33 @@ fn load_cache_file(path: &Path) -> Result<EpHealthCacheFile> {
     Ok(parsed)
 }
 
+fn load_success_cache_file(path: &Path) -> Result<EpSuccessCacheFile> {
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(EpSuccessCacheFile::default())
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let parsed = serde_json::from_str::<EpSuccessCacheFile>(&raw).unwrap_or_default();
+    if parsed.version != CACHE_SCHEMA_VERSION {
+        return Ok(EpSuccessCacheFile::default());
+    }
+
+    Ok(parsed)
+}
+
 fn save_cache_file(path: &Path, cache: &EpHealthCacheFile) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let raw = serde_json::to_string_pretty(cache)?;
+    fs::write(path, raw)?;
+    Ok(())
+}
+
+fn save_success_cache_file(path: &Path, cache: &EpSuccessCacheFile) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -139,11 +212,27 @@ fn entry_matches_key(entry: &EpHealthEntry, key: &EpCacheKey) -> bool {
         && entry.ort_api == key.ort_api
 }
 
+fn success_entry_matches_key(entry: &EpSuccessEntry, key: &EpCacheKey) -> bool {
+    entry.provider == key.provider
+        && entry.model_id == key.model_id
+        && entry.os == key.os
+        && entry.arch == key.arch
+        && entry.ort_api == key.ort_api
+}
+
 fn prune_expired_entries(cache: &mut EpHealthCacheFile, now: u64) -> bool {
     let before = cache.entries.len();
     cache
         .entries
         .retain(|entry| now.saturating_sub(entry.updated_at_unix) <= UNHEALTHY_TTL_SECS);
+    cache.entries.len() != before
+}
+
+fn prune_expired_success_entries(cache: &mut EpSuccessCacheFile, now: u64) -> bool {
+    let before = cache.entries.len();
+    cache
+        .entries
+        .retain(|entry| now.saturating_sub(entry.updated_at_unix) <= HEALTHY_TTL_SECS);
     cache.entries.len() != before
 }
 
@@ -212,6 +301,69 @@ fn mark_unhealthy_in_file(path: &Path, key: &EpCacheKey, reason: &str) -> Result
     }
 
     save_cache_file(path, &cache)
+}
+
+fn is_recently_healthy_in_file(
+    path: &Path,
+    key: &EpCacheKey,
+    bypass_enabled: bool,
+) -> Result<bool> {
+    if bypass_enabled {
+        return Ok(false);
+    }
+
+    let mut cache = load_success_cache_file(path)?;
+    let now = current_unix_secs();
+    let changed = prune_expired_success_entries(&mut cache, now);
+    let healthy = cache
+        .entries
+        .iter()
+        .any(|entry| success_entry_matches_key(entry, key));
+
+    if changed {
+        save_success_cache_file(path, &cache)?;
+    }
+
+    Ok(healthy)
+}
+
+fn mark_healthy_in_file(path: &Path, key: &EpCacheKey) -> Result<()> {
+    let mut cache = load_success_cache_file(path)?;
+    let now = current_unix_secs();
+    prune_expired_success_entries(&mut cache, now);
+
+    if let Some(entry) = cache
+        .entries
+        .iter_mut()
+        .find(|entry| success_entry_matches_key(entry, key))
+    {
+        entry.updated_at_unix = now;
+        entry.success_count = entry.success_count.saturating_add(1);
+    } else {
+        cache.entries.push(EpSuccessEntry {
+            provider: key.provider.clone(),
+            model_id: key.model_id.clone(),
+            os: key.os.clone(),
+            arch: key.arch.clone(),
+            ort_api: key.ort_api,
+            updated_at_unix: now,
+            success_count: 1,
+        });
+    }
+
+    save_success_cache_file(path, &cache)
+}
+
+fn clear_healthy_in_file(path: &Path, key: &EpCacheKey) -> Result<()> {
+    let mut cache = load_success_cache_file(path)?;
+    let before = cache.entries.len();
+    cache
+        .entries
+        .retain(|entry| !success_entry_matches_key(entry, key));
+    if cache.entries.len() != before {
+        save_success_cache_file(path, &cache)?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -286,5 +438,59 @@ mod tests {
 
         maybe_reset_cache_file(&cache_path, true).unwrap();
         assert!(!cache_path.exists());
+    }
+
+    #[test]
+    fn success_cache_roundtrip_marks_recently_healthy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_path = tmp.path().join("ep_success_cache.json");
+        let model_path = tmp.path().join("model.onnx");
+        let key = build_key("coreml", &model_path);
+
+        mark_healthy_in_file(&cache_path, &key).unwrap();
+        assert!(is_recently_healthy_in_file(&cache_path, &key, false).unwrap());
+    }
+
+    #[test]
+    fn success_cache_expiry_is_pruned() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_path = tmp.path().join("ep_success_cache.json");
+        let model_path = tmp.path().join("model.onnx");
+        let key = build_key("coreml", &model_path);
+
+        let mut cache = EpSuccessCacheFile::default();
+        cache.entries.push(EpSuccessEntry {
+            provider: key.provider.clone(),
+            model_id: key.model_id.clone(),
+            os: key.os.clone(),
+            arch: key.arch.clone(),
+            ort_api: key.ort_api,
+            updated_at_unix: current_unix_secs().saturating_sub(HEALTHY_TTL_SECS + 10),
+            success_count: 1,
+        });
+        save_success_cache_file(&cache_path, &cache).unwrap();
+
+        assert!(!is_recently_healthy_in_file(&cache_path, &key, false).unwrap());
+        let reloaded = load_success_cache_file(&cache_path).unwrap();
+        assert!(reloaded.entries.is_empty());
+    }
+
+    #[test]
+    fn mark_unhealthy_clears_success_cache_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let success_cache_path = tmp.path().join("ep_success_cache.json");
+        let unhealthy_cache_path = tmp.path().join("ep_cache.json");
+        let model_path = tmp.path().join("model.onnx");
+        let key = build_key("coreml", &model_path);
+
+        mark_healthy_in_file(&success_cache_path, &key).unwrap();
+        assert!(is_recently_healthy_in_file(&success_cache_path, &key, false).unwrap());
+
+        clear_healthy_in_file(&success_cache_path, &key).unwrap();
+        mark_unhealthy_in_file(&unhealthy_cache_path, &key, "bad output").unwrap();
+        assert!(!is_recently_healthy_in_file(&success_cache_path, &key, false).unwrap());
+        assert!(is_unhealthy_in_file(&unhealthy_cache_path, &key, false)
+            .unwrap()
+            .is_some());
     }
 }

--- a/src/io/ep_cache.rs
+++ b/src/io/ep_cache.rs
@@ -1,0 +1,290 @@
+#![cfg_attr(feature = "engine-mock", allow(dead_code))]
+
+use crate::{error::Result, io::paths::ep_cache_file};
+
+use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    path::Path,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+const CACHE_SCHEMA_VERSION: u32 = 1;
+const UNHEALTHY_TTL_SECS: u64 = 7 * 24 * 60 * 60;
+
+#[derive(Debug, Clone)]
+struct EpCacheKey {
+    provider: String,
+    model_id: String,
+    os: String,
+    arch: String,
+    ort_api: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EpHealthEntry {
+    provider: String,
+    model_id: String,
+    os: String,
+    arch: String,
+    ort_api: u32,
+    reason: String,
+    updated_at_unix: u64,
+    fail_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EpHealthCacheFile {
+    version: u32,
+    entries: Vec<EpHealthEntry>,
+}
+
+impl Default for EpHealthCacheFile {
+    fn default() -> Self {
+        Self {
+            version: CACHE_SCHEMA_VERSION,
+            entries: Vec::new(),
+        }
+    }
+}
+
+pub(crate) fn cache_bypass_enabled() -> bool {
+    env_flag_enabled("STEMMER_EP_CACHE_BYPASS")
+}
+
+pub(crate) fn maybe_reset_from_env() -> Result<()> {
+    let cache_path = ep_cache_file()?;
+    maybe_reset_cache_file(&cache_path, env_flag_enabled("STEMMER_EP_CACHE_RESET"))
+}
+
+pub(crate) fn is_unhealthy(provider: &str, model_path: &Path) -> Result<Option<String>> {
+    let cache_path = ep_cache_file()?;
+    let key = build_key(provider, model_path);
+    is_unhealthy_in_file(&cache_path, &key, cache_bypass_enabled())
+}
+
+pub(crate) fn mark_unhealthy(provider: &str, model_path: &Path, reason: &str) -> Result<()> {
+    let cache_path = ep_cache_file()?;
+    let key = build_key(provider, model_path);
+    mark_unhealthy_in_file(&cache_path, &key, reason)
+}
+
+fn env_flag_enabled(name: &str) -> bool {
+    let Some(raw) = std::env::var_os(name) else {
+        return false;
+    };
+
+    let value = raw.to_string_lossy().trim().to_ascii_lowercase();
+    if value.is_empty() {
+        return true;
+    }
+
+    !matches!(value.as_str(), "0" | "false" | "no" | "off")
+}
+
+fn build_key(provider: &str, model_path: &Path) -> EpCacheKey {
+    let model_id = model_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| model_path.to_string_lossy().into_owned());
+
+    EpCacheKey {
+        provider: provider.to_ascii_lowercase(),
+        model_id,
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        ort_api: ort::MINOR_VERSION,
+    }
+}
+
+fn current_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::from_secs(0))
+        .as_secs()
+}
+
+fn load_cache_file(path: &Path) -> Result<EpHealthCacheFile> {
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(EpHealthCacheFile::default())
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let parsed = serde_json::from_str::<EpHealthCacheFile>(&raw).unwrap_or_default();
+    if parsed.version != CACHE_SCHEMA_VERSION {
+        return Ok(EpHealthCacheFile::default());
+    }
+
+    Ok(parsed)
+}
+
+fn save_cache_file(path: &Path, cache: &EpHealthCacheFile) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let raw = serde_json::to_string_pretty(cache)?;
+    fs::write(path, raw)?;
+    Ok(())
+}
+
+fn entry_matches_key(entry: &EpHealthEntry, key: &EpCacheKey) -> bool {
+    entry.provider == key.provider
+        && entry.model_id == key.model_id
+        && entry.os == key.os
+        && entry.arch == key.arch
+        && entry.ort_api == key.ort_api
+}
+
+fn prune_expired_entries(cache: &mut EpHealthCacheFile, now: u64) -> bool {
+    let before = cache.entries.len();
+    cache
+        .entries
+        .retain(|entry| now.saturating_sub(entry.updated_at_unix) <= UNHEALTHY_TTL_SECS);
+    cache.entries.len() != before
+}
+
+fn maybe_reset_cache_file(path: &Path, reset_enabled: bool) -> Result<()> {
+    if !reset_enabled {
+        return Ok(());
+    }
+
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn is_unhealthy_in_file(
+    path: &Path,
+    key: &EpCacheKey,
+    bypass_enabled: bool,
+) -> Result<Option<String>> {
+    if bypass_enabled {
+        return Ok(None);
+    }
+
+    let mut cache = load_cache_file(path)?;
+    let now = current_unix_secs();
+    let changed = prune_expired_entries(&mut cache, now);
+
+    let reason = cache
+        .entries
+        .iter()
+        .find(|entry| entry_matches_key(entry, key))
+        .map(|entry| format!("{} ({} failures)", entry.reason, entry.fail_count));
+
+    if changed {
+        save_cache_file(path, &cache)?;
+    }
+
+    Ok(reason)
+}
+
+fn mark_unhealthy_in_file(path: &Path, key: &EpCacheKey, reason: &str) -> Result<()> {
+    let mut cache = load_cache_file(path)?;
+    let now = current_unix_secs();
+    prune_expired_entries(&mut cache, now);
+
+    if let Some(entry) = cache
+        .entries
+        .iter_mut()
+        .find(|entry| entry_matches_key(entry, key))
+    {
+        entry.reason = reason.to_string();
+        entry.updated_at_unix = now;
+        entry.fail_count = entry.fail_count.saturating_add(1);
+    } else {
+        cache.entries.push(EpHealthEntry {
+            provider: key.provider.clone(),
+            model_id: key.model_id.clone(),
+            os: key.os.clone(),
+            arch: key.arch.clone(),
+            ort_api: key.ort_api,
+            reason: reason.to_string(),
+            updated_at_unix: now,
+            fail_count: 1,
+        });
+    }
+
+    save_cache_file(path, &cache)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_roundtrip_marks_and_reads_unhealthy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_path = tmp.path().join("ep_cache.json");
+        let model_path = tmp.path().join("model.onnx");
+        let key = build_key("coreml", &model_path);
+
+        mark_unhealthy_in_file(&cache_path, &key, "near-silent runtime output").unwrap();
+        let reason = is_unhealthy_in_file(&cache_path, &key, false).unwrap();
+
+        assert!(reason.is_some());
+        let text = reason.unwrap();
+        assert!(text.contains("near-silent runtime output"));
+        assert!(text.contains("1 failures"));
+    }
+
+    #[test]
+    fn bypass_returns_none_even_when_cached() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_path = tmp.path().join("ep_cache.json");
+        let model_path = tmp.path().join("model.onnx");
+        let key = build_key("coreml", &model_path);
+
+        mark_unhealthy_in_file(&cache_path, &key, "bad output").unwrap();
+        let reason = is_unhealthy_in_file(&cache_path, &key, true).unwrap();
+
+        assert!(reason.is_none());
+    }
+
+    #[test]
+    fn expired_entries_are_pruned() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_path = tmp.path().join("ep_cache.json");
+        let model_path = tmp.path().join("model.onnx");
+        let key = build_key("coreml", &model_path);
+
+        let mut cache = EpHealthCacheFile::default();
+        cache.entries.push(EpHealthEntry {
+            provider: key.provider.clone(),
+            model_id: key.model_id.clone(),
+            os: key.os.clone(),
+            arch: key.arch.clone(),
+            ort_api: key.ort_api,
+            reason: "old failure".to_string(),
+            updated_at_unix: current_unix_secs().saturating_sub(UNHEALTHY_TTL_SECS + 10),
+            fail_count: 1,
+        });
+        save_cache_file(&cache_path, &cache).unwrap();
+
+        let reason = is_unhealthy_in_file(&cache_path, &key, false).unwrap();
+        assert!(reason.is_none());
+
+        let reloaded = load_cache_file(&cache_path).unwrap();
+        assert!(reloaded.entries.is_empty());
+    }
+
+    #[test]
+    fn reset_removes_cache_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_path = tmp.path().join("ep_cache.json");
+        let model_path = tmp.path().join("model.onnx");
+        let key = build_key("coreml", &model_path);
+
+        mark_unhealthy_in_file(&cache_path, &key, "bad output").unwrap();
+        assert!(cache_path.exists());
+
+        maybe_reset_cache_file(&cache_path, true).unwrap();
+        assert!(!cache_path.exists());
+    }
+}

--- a/src/io/paths.rs
+++ b/src/io/paths.rs
@@ -9,3 +9,11 @@ pub fn models_cache_dir() -> Result<PathBuf> {
     p.push("models");
     Ok(p)
 }
+
+pub fn ep_cache_file() -> Result<PathBuf> {
+    let proj = ProjectDirs::from("dev", "StemSplitter", "stem-splitter-core")
+        .ok_or(StemError::CacheDirUnavailable)?;
+    let mut p = PathBuf::from(proj.cache_dir());
+    p.push("ep_health_v1.json");
+    Ok(p)
+}

--- a/src/io/paths.rs
+++ b/src/io/paths.rs
@@ -17,3 +17,19 @@ pub fn ep_cache_file() -> Result<PathBuf> {
     p.push("ep_health_v1.json");
     Ok(p)
 }
+
+pub fn ep_probe_cache_file() -> Result<PathBuf> {
+    let proj = ProjectDirs::from("dev", "StemSplitter", "stem-splitter-core")
+        .ok_or(StemError::CacheDirUnavailable)?;
+    let mut p = PathBuf::from(proj.cache_dir());
+    p.push("ep_probe_success_v1.json");
+    Ok(p)
+}
+
+pub fn coreml_cache_dir() -> Result<PathBuf> {
+    let proj = ProjectDirs::from("dev", "StemSplitter", "stem-splitter-core")
+        .ok_or(StemError::CacheDirUnavailable)?;
+    let mut p = PathBuf::from(proj.cache_dir());
+    p.push("coreml");
+    Ok(p)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod model {
 
 pub mod io {
     pub mod crypto;
+    pub(crate) mod ep_cache;
     pub mod net;
     pub mod paths;
     pub mod progress;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod core {
     pub mod audio;
     pub mod dsp;
     pub mod engine;
+    pub(crate) mod ep;
     pub mod splitter;
 }
 

--- a/tests/model_manager.rs
+++ b/tests/model_manager.rs
@@ -88,36 +88,29 @@ fn downloads_and_caches_model_then_reuses_cache() {
     let tmp_cache = tempdir().unwrap();
     let _cache_home = CacheHomeGuard::set(tmp_cache.path());
 
-    let (model_bytes, sha_hex, size) = make_fake_model_bytes(256 * 1024); // 256 KiB
-
-    let server = MockServer::start();
-
-    let model_mock = server.mock(|when, then| {
-        let unique = tmp_cache
-            .path()
-            .file_name()
-            .unwrap()
-            .to_string_lossy()
-            .into_owned();
-        let model_path = format!("/mdx_4stem_v1_{unique}.onnx");
-        when.method(GET).path(model_path.as_str());
-        then.status(200)
-            .header("Content-Length", size.to_string().as_str())
-            .body(model_bytes.clone()); // serve bytes
-    });
-
     let unique = tmp_cache
         .path()
         .file_name()
         .unwrap()
         .to_string_lossy()
         .into_owned();
+    let (model_bytes, sha_hex, size) = make_fake_model_bytes(256 * 1024);
+
+    let server = MockServer::start();
+
     let model_name = format!("mdx_4stem_v1_{unique}");
     let file_name = format!("mdx_4stem_v1_{unique}.onnx");
+    let model_path = format!("/{file_name}");
     let model_url = format!("{}/{}", server.base_url(), file_name);
 
-    let manifest_body = manifest_json(&model_name, &file_name, &model_url, &sha_hex, size);
+    let model_mock = server.mock(|when, then| {
+        when.method(GET).path(model_path.as_str());
+        then.status(200)
+            .header("Content-Length", size.to_string().as_str())
+            .body(model_bytes.clone());
+    });
 
+    let manifest_body = manifest_json(&model_name, &file_name, &model_url, &sha_hex, size);
     let manifest_path = format!("/{model_name}.json");
 
     let manifest_mock = server.mock(|when, then| {
@@ -141,7 +134,7 @@ fn downloads_and_caches_model_then_reuses_cache() {
         "cache path should be stable"
     );
 
-    model_mock.assert_hits(1); // still exactly one hit total
+    model_mock.assert_hits(1);
 }
 
 #[test]
@@ -150,6 +143,12 @@ fn checksum_mismatch_returns_error() {
     let tmp_cache = tempdir().unwrap();
     let _cache_home = CacheHomeGuard::set(tmp_cache.path());
 
+    let unique = tmp_cache
+        .path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
     let (model_bytes, sha_hex, size) = make_fake_model_bytes(64 * 1024);
     let mut bad_sha = sha_hex.clone();
     let first = &bad_sha[0..1];
@@ -157,26 +156,19 @@ fn checksum_mismatch_returns_error() {
 
     let server = MockServer::start();
 
-    let unique = tmp_cache
-        .path()
-        .file_name()
-        .unwrap()
-        .to_string_lossy()
-        .into_owned();
-    let bad_path = format!("/bad_{unique}.onnx");
+    let model_name = format!("bad_model_{unique}");
+    let file_name = format!("bad_{unique}.onnx");
+    let model_path = format!("/{file_name}");
+    let model_url = format!("{}/{}", server.base_url(), file_name);
+
     let _model_mock = server.mock(|when, then| {
-        when.method(GET).path(bad_path.as_str());
+        when.method(GET).path(model_path.as_str());
         then.status(200)
             .header("Content-Length", size.to_string().as_str())
             .body(model_bytes.clone());
     });
 
-    let model_name = format!("bad_model_{unique}");
-    let file_name = format!("bad_{unique}.onnx");
-    let model_url = format!("{}/{}", server.base_url(), file_name);
-
     let manifest_body = manifest_json(&model_name, &file_name, &model_url, &bad_sha, size);
-
     let manifest_path = format!("/bad_{unique}.json");
 
     let _manifest_mock = server.mock(|when, then| {

--- a/tests/model_manager.rs
+++ b/tests/model_manager.rs
@@ -1,10 +1,38 @@
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 use sha2::{Digest, Sha256};
+use std::sync::{Mutex, OnceLock};
 use tempfile::tempdir;
 
 use httpmock::prelude::*;
 
 use stem_splitter_core::model::model_manager::ensure_model;
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct CacheHomeGuard {
+    previous: Option<String>,
+}
+
+impl CacheHomeGuard {
+    fn set(path: &std::path::Path) -> Self {
+        let previous = std::env::var("XDG_CACHE_HOME").ok();
+        std::env::set_var("XDG_CACHE_HOME", path);
+        Self { previous }
+    }
+}
+
+impl Drop for CacheHomeGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = &self.previous {
+            std::env::set_var("XDG_CACHE_HOME", previous);
+        } else {
+            std::env::remove_var("XDG_CACHE_HOME");
+        }
+    }
+}
 
 fn make_fake_model_bytes(len: usize) -> (Vec<u8>, String, u64) {
     let mut data = vec![0u8; len];
@@ -56,34 +84,50 @@ fn manifest_json(
 
 #[test]
 fn downloads_and_caches_model_then_reuses_cache() {
+    let _lock = env_lock().lock().unwrap();
     let tmp_cache = tempdir().unwrap();
-    std::env::set_var("XDG_CACHE_HOME", tmp_cache.path());
+    let _cache_home = CacheHomeGuard::set(tmp_cache.path());
 
     let (model_bytes, sha_hex, size) = make_fake_model_bytes(256 * 1024); // 256 KiB
 
     let server = MockServer::start();
 
     let model_mock = server.mock(|when, then| {
-        when.method(GET).path("/mdx_4stem_v1.onnx");
+        let unique = tmp_cache
+            .path()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let model_path = format!("/mdx_4stem_v1_{unique}.onnx");
+        when.method(GET).path(model_path.as_str());
         then.status(200)
             .header("Content-Length", size.to_string().as_str())
             .body(model_bytes.clone()); // serve bytes
     });
 
-    let model_name = "mdx_4stem_v1";
-    let file_name = "mdx_4stem_v1.onnx";
+    let unique = tmp_cache
+        .path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    let model_name = format!("mdx_4stem_v1_{unique}");
+    let file_name = format!("mdx_4stem_v1_{unique}.onnx");
     let model_url = format!("{}/{}", server.base_url(), file_name);
 
-    let manifest_body = manifest_json(model_name, file_name, &model_url, &sha_hex, size);
+    let manifest_body = manifest_json(&model_name, &file_name, &model_url, &sha_hex, size);
+
+    let manifest_path = format!("/{model_name}.json");
 
     let manifest_mock = server.mock(|when, then| {
-        when.method(GET).path("/mdx_4stem_v1.json");
+        when.method(GET).path(manifest_path.as_str());
         then.status(200)
             .header("Content-Type", "application/json")
             .body(manifest_body.clone());
     });
 
-    let manifest_url = format!("{}/mdx_4stem_v1.json", server.base_url());
+    let manifest_url = format!("{}{}", server.base_url(), manifest_path);
 
     let handle = ensure_model("ignored", Some(&manifest_url)).expect("first ensure_model failed");
     assert!(handle.local_path.exists(), "cached model should exist");
@@ -102,8 +146,9 @@ fn downloads_and_caches_model_then_reuses_cache() {
 
 #[test]
 fn checksum_mismatch_returns_error() {
+    let _lock = env_lock().lock().unwrap();
     let tmp_cache = tempdir().unwrap();
-    std::env::set_var("XDG_CACHE_HOME", tmp_cache.path());
+    let _cache_home = CacheHomeGuard::set(tmp_cache.path());
 
     let (model_bytes, sha_hex, size) = make_fake_model_bytes(64 * 1024);
     let mut bad_sha = sha_hex.clone();
@@ -112,27 +157,36 @@ fn checksum_mismatch_returns_error() {
 
     let server = MockServer::start();
 
+    let unique = tmp_cache
+        .path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    let bad_path = format!("/bad_{unique}.onnx");
     let _model_mock = server.mock(|when, then| {
-        when.method(GET).path("/bad.onnx");
+        when.method(GET).path(bad_path.as_str());
         then.status(200)
             .header("Content-Length", size.to_string().as_str())
             .body(model_bytes.clone());
     });
 
-    let model_name = "bad_model";
-    let file_name = "bad.onnx";
+    let model_name = format!("bad_model_{unique}");
+    let file_name = format!("bad_{unique}.onnx");
     let model_url = format!("{}/{}", server.base_url(), file_name);
 
-    let manifest_body = manifest_json(model_name, file_name, &model_url, &bad_sha, size);
+    let manifest_body = manifest_json(&model_name, &file_name, &model_url, &bad_sha, size);
+
+    let manifest_path = format!("/bad_{unique}.json");
 
     let _manifest_mock = server.mock(|when, then| {
-        when.method(GET).path("/bad.json");
+        when.method(GET).path(manifest_path.as_str());
         then.status(200)
             .header("Content-Type", "application/json")
             .body(manifest_body.clone());
     });
 
-    let manifest_url = format!("{}/bad.json", server.base_url());
+    let manifest_url = format!("{}{}", server.base_url(), manifest_path);
 
     match ensure_model("ignored", Some(&manifest_url)) {
         Ok(_) => panic!("expected checksum error, but got Ok"),


### PR DESCRIPTION
- Improve acceleration reliability with better execution-provider selection, health checks, and CPU fallback
- Add `XNNPACK` as an additional accelerated fallback alongside CUDA, CoreML, DirectML, and oneDNN
- Reduce end-to-end split time with streaming stem writes, reused hot-path buffers, and lower post-processing overhead
- Add advanced tuning controls for provider selection, CoreML, ONNX Runtime threading, and performance diagnostics

### Performance
- Up to ~40% faster end-to-end split times in internal testing, depending on hardware and provider